### PR TITLE
elastio ec2 backup ecs stopped task

### DIFF
--- a/elastio-ec2-backup_ecs_stopped_task/.gitignore
+++ b/elastio-ec2-backup_ecs_stopped_task/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/elastio-ec2-backup_ecs_stopped_task/Dockerfile
+++ b/elastio-ec2-backup_ecs_stopped_task/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+# Version elastio cli what will use like base image.
+# Most likely this is not the latest version of elastio cli.
+# You can find the latest version at this link.
+# https://gallery.ecr.aws/elastio-dev/elastio-cli
+FROM public.ecr.aws/elastio-dev/elastio-cli:0.17.0-master
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y python3-pip python3
+COPY requirements.txt  ./
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
+COPY failed_ecs_handler.py ./
+COPY failed_ecs_handler_config.py ./
+
+ENTRYPOINT [ ]
+CMD python3 failed_ecs_handler.py

--- a/elastio-ec2-backup_ecs_stopped_task/Dockerfile
+++ b/elastio-ec2-backup_ecs_stopped_task/Dockerfile
@@ -4,14 +4,27 @@
 # Most likely this is not the latest version of elastio cli.
 # You can find the latest version at this link.
 # https://gallery.ecr.aws/elastio-dev/elastio-cli
-FROM public.ecr.aws/elastio-dev/elastio-cli:0.17.0-master
+FROM public.ecr.aws/elastio-dev/elastio-cli:latest
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y python3-pip python3
+RUN apt-get update
+RUN \
+    set -ex \
+    && apt-get install -y --no-install-suggests --no-install-recommends \
+        python3-pip python3
+
 COPY requirements.txt  ./
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
+
 COPY failed_ecs_handler.py ./
 COPY failed_ecs_handler_config.py ./
 
-ENTRYPOINT [ ]
-CMD python3 failed_ecs_handler.py
+# Clean up
+RUN \
+   set -ex \
+   && apt-get purge python3-pip -y \
+   && apt-get autoremove -y \
+   && apt-get clean -y \
+   && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["python3"]
+CMD ["failed_ecs_handler.py"]

--- a/elastio-ec2-backup_ecs_stopped_task/Dockerfile
+++ b/elastio-ec2-backup_ecs_stopped_task/Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1
 
 # Version elastio cli what will use like base image.
-# Most likely this is not the latest version of elastio cli.
 # You can find the latest version at this link.
 # https://gallery.ecr.aws/elastio-dev/elastio-cli
 FROM public.ecr.aws/elastio-dev/elastio-cli:latest

--- a/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler.py
+++ b/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler.py
@@ -1,5 +1,8 @@
 
-import boto3, subprocess, datetime, json
+import boto3
+import subprocess
+import datetime
+import json
 
 from failed_ecs_handler_config import CLUSTER_NAME
 
@@ -50,4 +53,4 @@ if tasks != []:
             else:
                 print(f"The time to backup task {task_arn} has expired.")
 else:
-    print("You don't have stopped task.")
+    print("You don't have any stopped tasks.")

--- a/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler.py
+++ b/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler.py
@@ -1,0 +1,53 @@
+
+import boto3, subprocess, datetime, json
+
+from failed_ecs_handler_config import CLUSTER_NAME
+
+cluster_name = CLUSTER_NAME
+expired_time = 20 # minutes
+ecs_client = boto3.client('ecs')
+
+# Getting list of stopped task from cluster.
+list_task_response = ecs_client.list_tasks(
+    cluster=cluster_name,
+    desiredStatus='STOPPED',
+    launchType='EC2'
+)
+# Getting recovery point list from Elastio CLI.
+res = subprocess.run(
+        ['elastio', 'rp', 'list', '--output-format', 'json', '--type', 'ec2'],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
+rps = [json.loads(rp) for rp in res.stdout.splitlines()]
+# Getting arn previously backed up ecs tasks.
+rps_tasks_arn = (rp['tags']['taskARN'] for rp in rps[0] if 'taskARN' in rp['tags'].keys())
+tasks = list_task_response['taskArns']
+if tasks != []:
+    for t in tasks:
+        # Getting task description
+        t_desc = ecs_client.describe_tasks(
+            cluster=cluster_name,
+            tasks=[t, ]
+        )
+        task_arn = t_desc['tasks'][0]['taskArn']
+        if task_arn not in rps_tasks_arn:
+            print("New task ARN: {}.".format(task_arn))
+            task_stopped_at = t_desc['tasks'][0]['pullStoppedAt']
+            delta_time = task_stopped_at + datetime.timedelta(minutes=expired_time)
+            # If the task stopped more than 20 minutes ago, the instance is most likely already terminated.
+            if delta_time > datetime.datetime.now(datetime.timezone.utc):
+                container_arn = t_desc['tasks'][0]['containerInstanceArn']
+                # Getting container description by task
+                container_instance_desc = ecs_client.describe_container_instances(
+                    cluster=cluster_name,
+                    containerInstances=(container_arn, )
+                )
+                for container in container_instance_desc['containerInstances']:
+                    subprocess.run(
+                            ['elastio', 'ec2', 'backup', '--instance-id', container['ec2InstanceId'],'--vault', 'defl', '--tag', 'taskARN={task_arn}'.format(task_arn=task_arn)]
+                        )
+                    print(f"Elastio start job to backup {container['ec2InstanceId']} instance.")
+            else:
+                print(f"The time to backup task {task_arn} has expired.")
+else:
+    print("You don't have stopped task.")

--- a/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler_config.py
+++ b/elastio-ec2-backup_ecs_stopped_task/failed_ecs_handler_config.py
@@ -1,0 +1,1 @@
+CLUSTER_NAME = 'ec2-cluster'

--- a/elastio-ec2-backup_ecs_stopped_task/readme.md
+++ b/elastio-ec2-backup_ecs_stopped_task/readme.md
@@ -13,13 +13,13 @@
 ## Step 2 - Roles
 
 1. From AWS console, select IAM service =>`Roles`.
-1. If you already have a role for ECS tasks, add the following permissions:
+1. If you already have a role for ECS tasks, add the following policies to the role:
 
-    1. AmazonECSTaskExecutionRolePolicy,
-    1. SecretsManagerReadWrite,
-    1. AmazonECS_FullAccess,
-    1. ECR_FullAccess,
-    1. ElastioBackupAdmin
+    1. `AmazonECSTaskExecutionRolePolicy`
+    1. `SecretsManagerReadWrite`
+    1. `AmazonECS_FullAccess`
+    1. `ECR_FullAccess`
+    1. `ElastioBackupAdmin`
 
     or create a new role with these permissions.
 Creating a new role follow these steps:
@@ -31,11 +31,11 @@ Creating a new role follow these steps:
     then choose "Next": "Permissions".
 1. In the "Attach permissions policies" section, search for
 
-    1. AmazonECSTaskExecutionRolePolicy,
-    1. SecretsManagerReadWrite,
-    1. AmazonECS_FullAccess,
-    1. ECR_FullAccess,
-    1. ElastioBackupAdmin
+    1. `AmazonECSTaskExecutionRolePolicy`
+    1. `SecretsManagerReadWrite`
+    1. `AmazonECS_FullAccess`
+    1. `ECR_FullAccess`
+    1. `ElastioBackupAdmin`
 
     select "Policies", then choose "Next": "Tags".
 1. For Add tags (optional), specify custom tags to
@@ -50,7 +50,7 @@ Creating a new role follow these steps:
 1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py
     and put data about topic, brokers, vault.
 1. Create ECR repository.
-1. Register your docker cli by getting the ecr public image with the command:
+1. Register your docker CLI by getting the ECR public image with the command:
 
     ```console
     aws ecr-public get-login-password --region us-east-1 | \

--- a/elastio-ec2-backup_ecs_stopped_task/readme.md
+++ b/elastio-ec2-backup_ecs_stopped_task/readme.md
@@ -1,4 +1,4 @@
-# Elastio ec2 backup ecs stopped task
+# Elastio EC2 backup ECS stopped task
 1. Create ECR polices:
     1. From AWS console, select "IAM service" =>`Policies` =>'Create Policy'.
     2. Under the **Service** tab select `Elastic Container Registry`.
@@ -15,15 +15,14 @@
         1. In the navigation pane, choose "Roles" =>"Create role".
         2. In the "Select type of trusted entity section", choose "AWS service" => "Elastic Container Service".
         3. In "Select your use case", select the "Elastic Container Service Task", then choose "Next": "Permissions".
-        4. In the "Attach permissions policies" section, search for ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, ECR_FullAccess, AmazonECS_FullAccess, ElastioFullAdmin``` select "Policies", then choose "Next": "Tags".
+        4. In the "Attach permissions policies" section, search for ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, ECR_FullAccess, AmazonECS_FullAccess, ElastioBackupAdmin``` select "Policies", then choose "Next": "Tags".
         5. For Add tags (optional), specify custom tags to associate with the policy and then choose "Next": "Review".
         6. For Role name, type `ecs_task_execution_role` and choose "Create role".
 
 3. Build and push a docker image:
-    > Before you start this section, review the dockerfile and read its comments.
     > You can find the latest version by following this link. https://gallery.ecr.aws/elastio-dev/elastio-cli
     1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py and put data about topic, brokers, vault.
-    2. Create ECR respository.
+    2. Create ECR repository.
     3. Register your docker cli by getting the ecr public image with the command:
         ```aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws```
     4. Open the ECR repository you have created earlier and press the button "View push commands". The screen will list four commands. Run them in your terminal to build the docker image.

--- a/elastio-ec2-backup_ecs_stopped_task/readme.md
+++ b/elastio-ec2-backup_ecs_stopped_task/readme.md
@@ -1,0 +1,67 @@
+# Elastio ec2 backup ecs stopped task
+1. Create ECR polices:
+    1. From AWS console, select "IAM service" =>`Policies` =>'Create Policy'.
+    2. Under the **Service** tab select `Elastic Container Registry`.
+    3. Under the **Actions** tab select `All Elastic Container Registry actions (ecr:*)`.
+    4. Under the **Resources** tab select `specific` =>`Add ARN`. Then choose the region, leave your account number and select "Any" for the Repository name.
+    5. Enter 'ECR_FullAccess' as a policy name.
+
+2. Roles
+    1. From AWS console, select IAM service =>`Roles`.
+    2. If you already have a role for ECS tasks, add the following permissions: 
+    ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, AmazonECS_FullAccess, ECR_FullAccess, ElastioFullAdmin``` or create a new role with these permissions.
+        
+        Creating a new role follow these steps:
+        1. In the navigation pane, choose "Roles" =>"Create role".
+        2. In the "Select type of trusted entity section", choose "AWS service" => "Elastic Container Service".
+        3. In "Select your use case", select the "Elastic Container Service Task", then choose "Next": "Permissions".
+        4. In the "Attach permissions policies" section, search for ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, ECR_FullAccess, AmazonECS_FullAccess, ElastioFullAdmin``` select "Policies", then choose "Next": "Tags".
+        5. For Add tags (optional), specify custom tags to associate with the policy and then choose "Next": "Review".
+        6. For Role name, type `ecs_task_execution_role` and choose "Create role".
+
+3. Build and push a docker image:
+    > Before you start this section, review the dockerfile and read its comments.
+    > You can find the latest version by following this link. https://gallery.ecr.aws/elastio-dev/elastio-cli
+    1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py and put data about topic, brokers, vault.
+    2. Create ECR respository.
+    3. Register your docker cli by getting the ecr public image with the command:
+        ```aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws```
+    4. Open the ECR repository you have created earlier and press the button "View push commands". The screen will list four commands. Run them in your terminal to build the docker image.
+4. Create a Fargate Cluster.
+    1. From the AWS console, select `Elastic Container Service`=>`Create Cluster`.
+    2. Under "Select" cluster template, select "networking only".
+    3. Enter your cluster name and press `Create`.
+5. Create an ECS Task.
+    1. Select `Task Definitions` from the left-side menu. Then choose `Create new task definition`.
+    2. Select Fargate => "Next Step".
+    3. Enter `Task definition name`.
+    4. In the `Task role` field choose `ecs_task_execution_role`.
+    5. Choose `Linux` as an operating system family.
+    6. Task execution role.
+    7. Task memory (GB): 4GB
+    8. Task CPU (vCPU): 1vCPU
+    9. Select `Add container`.
+    10. Enter a container name.
+    11. In the image field put URL of your docker image from ECR repository. Copy the arn from the ECS tab.
+    12. Set `Private repository authentication` to true
+    13. Memory Limits (MiB):
+        1. Soft limit: `4096`
+        2. Hard limit: `4096`
+    14. Press `Add`.
+    15. Lastly, press `Create` button.
+6. Run the ECS schedule task.
+    1. Select your cluster in ECS Clusters.
+    2. In the navigation tab choose `Scheduled Tasks`.
+    3. Press `Create` button.
+    4. Enter `Schedule rule name`=>`Target id`.
+    5. Launch type choose `Fargate`.
+    6. Task Definition, choose your task definition.
+    7. Select a VPC from the list in the Cluster VPC field.
+    8. Add at least one subnet.
+    9. Enable Auto-assign public IP.
+    10. Press `Create` button. This will run the task according to the selected schedule.
+7. Get logs.
+    1. Open AWS Cloud Watch Service
+    2. In the left side menu, choose `Logs`=>`Log group`.
+    3. In the search field, enter your schedule task definition name.
+    4. Choose in result your task definition with logs.

--- a/elastio-ec2-backup_ecs_stopped_task/readme.md
+++ b/elastio-ec2-backup_ecs_stopped_task/readme.md
@@ -3,57 +3,43 @@
 ## Step 1 - Create ECR polices
 
 1. From AWS console, select "IAM service" =>`Policies` =>'Create Policy'.
-
 1. Under the **Service** tab select `Elastic Container Registry`.
-
 1. Under the **Actions** tab select `All Elastic Container Registry actions (ecr:*)`.
-
 1. Under the **Resources** tab select `specific` =>`Add ARN`.
     Then choose the region, leave your account number and
     select "Any" for the Repository name.
-
 1. Enter 'ECR_FullAccess' as a policy name.
 
 ## Step 2 - Roles
 
 1. From AWS console, select IAM service =>`Roles`.
-
 1. If you already have a role for ECS tasks, add the following permissions:
 
-    ```text
-    AmazonECSTaskExecutionRolePolicy,
-    SecretsManagerReadWrite,
-    AmazonECS_FullAccess,
-    ECR_FullAccess,
-    ElastioBackupAdmin
-    ```
+    1. AmazonECSTaskExecutionRolePolicy,
+    1. SecretsManagerReadWrite,
+    1. AmazonECS_FullAccess,
+    1. ECR_FullAccess,
+    1. ElastioBackupAdmin
 
-or create a new role with these permissions.
+    or create a new role with these permissions.
 Creating a new role follow these steps:
 
 1. In the navigation pane, choose "Roles" =>"Create role".
-
 1. In the "Select type of trusted entity section",
     choose "AWS service" => "Elastic Container Service".
-
 1. In "Select your use case", select the "Elastic Container Service Task",
     then choose "Next": "Permissions".
-
 1. In the "Attach permissions policies" section, search for
 
-    ```text
-    AmazonECSTaskExecutionRolePolicy,
-    SecretsManagerReadWrite,
-    AmazonECS_FullAccess,
-    ECR_FullAccess,
-    ElastioBackupAdmin
-    ```
+    1. AmazonECSTaskExecutionRolePolicy,
+    1. SecretsManagerReadWrite,
+    1. AmazonECS_FullAccess,
+    1. ECR_FullAccess,
+    1. ElastioBackupAdmin
 
     select "Policies", then choose "Next": "Tags".
-
 1. For Add tags (optional), specify custom tags to
     associate with the policy and then choose "Next": "Review".
-
 1. For Role name, type `ecs_task_execution_role` and choose "Create role".
 
 ## Step 3 - Build and push a docker image
@@ -63,12 +49,10 @@ Creating a new role follow these steps:
 
 1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py
     and put data about topic, brokers, vault.
-
 1. Create ECR repository.
-
 1. Register your docker cli by getting the ecr public image with the command:
 
-    ```docker
+    ```console
     aws ecr-public get-login-password --region us-east-1 | \
     docker login --username AWS --password-stdin public.ecr.aws
     ```
@@ -81,77 +65,48 @@ Creating a new role follow these steps:
 ## Step 4 - Create a Fargate Cluster
 
 1. From the AWS console, select `Elastic Container Service`=>`Create Cluster`.
-
 1. Under "Select" cluster template, select "networking only".
-
 1. Enter your cluster name and press `Create`.
 
 ## Step 5 - Create an ECS Task
 
 1. Select `Task Definitions` from the left-side menu. Then choose
     `Create new task definition`.
-
 1. Select Fargate => "Next Step".
-
 1. Enter `Task definition name`.
-
 1. In the `Task role` field choose `ecs_task_execution_role`.
-
 1. Choose `Linux` as an operating system family.
-
 1. Task execution role.
-
 1. Task memory (GB): 4GB
-
 1. Task CPU (vCPU): 1vCPU
-
 1. Select `Add container`.
-
 1. Enter a container name.
-
 1. In the image field put URL of your docker image from ECR repository.
     Copy the arn from the ECS tab.
 1. Set `Private repository authentication` to true
-
 1. Memory Limits (MiB):
-
     1. Soft limit: `4096`
-
     1. Hard limit: `4096`
-
 1. Press `Add`.
-
 1. Lastly, press `Create` button.
 
 ## Step 6 - Run the ECS schedule task
 
 1. Select your cluster in ECS Clusters.
-
 1. In the navigation tab choose `Scheduled Tasks`.
-
 1. Press `Create` button.
-
 1. Enter `Schedule rule name`=>`Target id`.
-
 1. Launch type choose `Fargate`.
-
 1. Task Definition, choose your task definition.
-
 1. Select a VPC from the list in the Cluster VPC field.
-
 1. Add at least one subnet.
-
 1. Enable Auto-assign public IP.
-
 1. Press `Create` button.
     This will run the task according to the selected schedule.
 
 ## Step 7 - Get logs
 
 1. Open AWS Cloud Watch Service
-
 1. In the left side menu, choose `Logs`=>`Log group`.
-
 1. In the search field, enter your schedule task definition name.
-
 1. Choose in result your task definition with logs.

--- a/elastio-ec2-backup_ecs_stopped_task/readme.md
+++ b/elastio-ec2-backup_ecs_stopped_task/readme.md
@@ -1,66 +1,157 @@
 # Elastio EC2 backup ECS stopped task
-1. Create ECR polices:
-    1. From AWS console, select "IAM service" =>`Policies` =>'Create Policy'.
-    2. Under the **Service** tab select `Elastic Container Registry`.
-    3. Under the **Actions** tab select `All Elastic Container Registry actions (ecr:*)`.
-    4. Under the **Resources** tab select `specific` =>`Add ARN`. Then choose the region, leave your account number and select "Any" for the Repository name.
-    5. Enter 'ECR_FullAccess' as a policy name.
 
-2. Roles
-    1. From AWS console, select IAM service =>`Roles`.
-    2. If you already have a role for ECS tasks, add the following permissions: 
-    ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, AmazonECS_FullAccess, ECR_FullAccess, ElastioFullAdmin``` or create a new role with these permissions.
-        
-        Creating a new role follow these steps:
-        1. In the navigation pane, choose "Roles" =>"Create role".
-        2. In the "Select type of trusted entity section", choose "AWS service" => "Elastic Container Service".
-        3. In "Select your use case", select the "Elastic Container Service Task", then choose "Next": "Permissions".
-        4. In the "Attach permissions policies" section, search for ```AmazonECSTaskExecutionRolePolicy, SecretsManagerReadWrite, ECR_FullAccess, AmazonECS_FullAccess, ElastioBackupAdmin``` select "Policies", then choose "Next": "Tags".
-        5. For Add tags (optional), specify custom tags to associate with the policy and then choose "Next": "Review".
-        6. For Role name, type `ecs_task_execution_role` and choose "Create role".
+## Step 1 - Create ECR polices
 
-3. Build and push a docker image:
-    > You can find the latest version by following this link. https://gallery.ecr.aws/elastio-dev/elastio-cli
-    1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py and put data about topic, brokers, vault.
-    2. Create ECR repository.
-    3. Register your docker cli by getting the ecr public image with the command:
-        ```aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws```
-    4. Open the ECR repository you have created earlier and press the button "View push commands". The screen will list four commands. Run them in your terminal to build the docker image.
-4. Create a Fargate Cluster.
-    1. From the AWS console, select `Elastic Container Service`=>`Create Cluster`.
-    2. Under "Select" cluster template, select "networking only".
-    3. Enter your cluster name and press `Create`.
-5. Create an ECS Task.
-    1. Select `Task Definitions` from the left-side menu. Then choose `Create new task definition`.
-    2. Select Fargate => "Next Step".
-    3. Enter `Task definition name`.
-    4. In the `Task role` field choose `ecs_task_execution_role`.
-    5. Choose `Linux` as an operating system family.
-    6. Task execution role.
-    7. Task memory (GB): 4GB
-    8. Task CPU (vCPU): 1vCPU
-    9. Select `Add container`.
-    10. Enter a container name.
-    11. In the image field put URL of your docker image from ECR repository. Copy the arn from the ECS tab.
-    12. Set `Private repository authentication` to true
-    13. Memory Limits (MiB):
-        1. Soft limit: `4096`
-        2. Hard limit: `4096`
-    14. Press `Add`.
-    15. Lastly, press `Create` button.
-6. Run the ECS schedule task.
-    1. Select your cluster in ECS Clusters.
-    2. In the navigation tab choose `Scheduled Tasks`.
-    3. Press `Create` button.
-    4. Enter `Schedule rule name`=>`Target id`.
-    5. Launch type choose `Fargate`.
-    6. Task Definition, choose your task definition.
-    7. Select a VPC from the list in the Cluster VPC field.
-    8. Add at least one subnet.
-    9. Enable Auto-assign public IP.
-    10. Press `Create` button. This will run the task according to the selected schedule.
-7. Get logs.
-    1. Open AWS Cloud Watch Service
-    2. In the left side menu, choose `Logs`=>`Log group`.
-    3. In the search field, enter your schedule task definition name.
-    4. Choose in result your task definition with logs.
+1. From AWS console, select "IAM service" =>`Policies` =>'Create Policy'.
+
+1. Under the **Service** tab select `Elastic Container Registry`.
+
+1. Under the **Actions** tab select `All Elastic Container Registry actions (ecr:*)`.
+
+1. Under the **Resources** tab select `specific` =>`Add ARN`.
+    Then choose the region, leave your account number and
+    select "Any" for the Repository name.
+
+1. Enter 'ECR_FullAccess' as a policy name.
+
+## Step 2 - Roles
+
+1. From AWS console, select IAM service =>`Roles`.
+
+1. If you already have a role for ECS tasks, add the following permissions:
+
+    ```text
+    AmazonECSTaskExecutionRolePolicy,
+    SecretsManagerReadWrite,
+    AmazonECS_FullAccess,
+    ECR_FullAccess,
+    ElastioBackupAdmin
+    ```
+
+or create a new role with these permissions.
+Creating a new role follow these steps:
+
+1. In the navigation pane, choose "Roles" =>"Create role".
+
+1. In the "Select type of trusted entity section",
+    choose "AWS service" => "Elastic Container Service".
+
+1. In "Select your use case", select the "Elastic Container Service Task",
+    then choose "Next": "Permissions".
+
+1. In the "Attach permissions policies" section, search for
+
+    ```text
+    AmazonECSTaskExecutionRolePolicy,
+    SecretsManagerReadWrite,
+    AmazonECS_FullAccess,
+    ECR_FullAccess,
+    ElastioBackupAdmin
+    ```
+
+    select "Policies", then choose "Next": "Tags".
+
+1. For Add tags (optional), specify custom tags to
+    associate with the policy and then choose "Next": "Review".
+
+1. For Role name, type `ecs_task_execution_role` and choose "Create role".
+
+## Step 3 - Build and push a docker image
+
+> You can find the latest version by following this link.
+<https://gallery.ecr.aws/elastio-dev/elastio-cli>
+
+1. Edit file contrib/elastio-ec2-backup-ecs-stopped-task/failed_ecs_handler_config.py
+    and put data about topic, brokers, vault.
+
+1. Create ECR repository.
+
+1. Register your docker cli by getting the ecr public image with the command:
+
+    ```docker
+    aws ecr-public get-login-password --region us-east-1 | \
+    docker login --username AWS --password-stdin public.ecr.aws
+    ```
+
+1. Open the ECR repository you have created earlier
+    and press the button "View push commands".
+    The screen will list four commands.
+    Run them in your terminal to build the docker image.
+
+## Step 4 - Create a Fargate Cluster
+
+1. From the AWS console, select `Elastic Container Service`=>`Create Cluster`.
+
+1. Under "Select" cluster template, select "networking only".
+
+1. Enter your cluster name and press `Create`.
+
+## Step 5 - Create an ECS Task
+
+1. Select `Task Definitions` from the left-side menu. Then choose
+    `Create new task definition`.
+
+1. Select Fargate => "Next Step".
+
+1. Enter `Task definition name`.
+
+1. In the `Task role` field choose `ecs_task_execution_role`.
+
+1. Choose `Linux` as an operating system family.
+
+1. Task execution role.
+
+1. Task memory (GB): 4GB
+
+1. Task CPU (vCPU): 1vCPU
+
+1. Select `Add container`.
+
+1. Enter a container name.
+
+1. In the image field put URL of your docker image from ECR repository.
+    Copy the arn from the ECS tab.
+1. Set `Private repository authentication` to true
+
+1. Memory Limits (MiB):
+
+    1. Soft limit: `4096`
+
+    1. Hard limit: `4096`
+
+1. Press `Add`.
+
+1. Lastly, press `Create` button.
+
+## Step 6 - Run the ECS schedule task
+
+1. Select your cluster in ECS Clusters.
+
+1. In the navigation tab choose `Scheduled Tasks`.
+
+1. Press `Create` button.
+
+1. Enter `Schedule rule name`=>`Target id`.
+
+1. Launch type choose `Fargate`.
+
+1. Task Definition, choose your task definition.
+
+1. Select a VPC from the list in the Cluster VPC field.
+
+1. Add at least one subnet.
+
+1. Enable Auto-assign public IP.
+
+1. Press `Create` button.
+    This will run the task according to the selected schedule.
+
+## Step 7 - Get logs
+
+1. Open AWS Cloud Watch Service
+
+1. In the left side menu, choose `Logs`=>`Log group`.
+
+1. In the search field, enter your schedule task definition name.
+
+1. Choose in result your task definition with logs.

--- a/elastio-ec2-backup_ecs_stopped_task/requirements.txt
+++ b/elastio-ec2-backup_ecs_stopped_task/requirements.txt
@@ -1,0 +1,7 @@
+boto3==1.24.13
+botocore==1.27.13
+jmespath==1.0.1
+python-dateutil==2.8.2
+s3transfer==0.6.0
+six==1.16.0
+urllib3==1.26.9


### PR DESCRIPTION
Script for monitoring tasks in an ECS ec2 cluster. Getting all stopped tasks on the cluster, if the task was stopped less than 20 minutes ago, the backup will start, if later, then most likely the instance is already terminated.