### PR TITLE
Script to backup Oracle RDS with s3 upload monitor 

### DIFF
--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -1,0 +1,30 @@
+# Oracle Backup via RMAN, ssstar and Elastio
+
+---
+
+Script uses `rdsadmin.rdsadmin_rman_util` and `rdsadmin.rdsadmin_s3_tasks.upload_to_s3` Amazon RDS procedures to backup Oracle DB instance and upload backed up files from your DB instance to an Amazon S3 bucket. Then streams the files to Elastio using `ssstar` utility.
+
+**Useful articles:**
+ - [Performing common RMAN tasks for Oracle DB instances](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.CommonDBATasks.RMAN.html)
+ - [Amazon S3 integration](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-s3-integration.html)
+
+## Requirements
+- [ssstar](https://github.com/elastio/ssstar)
+- [Oracle Instant Client](https://www.oracle.com/database/technologies/instant-client/downloads.html)
+- AWS CLI
+- Elastio CLI
+
+## Usage
+
+Copy the script to instance with next software instelled:
+- ssstar
+- Oracle Instant Client including sqlplus
+- AWS CLI
+- Elastio CLI
+
+Test connection to the Oracle RDS instans:
+```
+sqlplus username/password@aws-rds-hostname:1521/SID
+```
+
+Change script variables according to your environment configuration and run script.

--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -26,5 +26,8 @@ Test connection to the Oracle RDS instans:
 ```
 sqlplus username/password@aws-rds-hostname:1521/SID
 ```
+Make sure Elastio CLI is configured and has connection to the Elastio vault.
 
-Change script variables according to your environment configuration and run script.
+Change script variables (Oracle DB credentials, s3 bucket name) according to your environment configuration and run script.
+
+Script will create Oracle backup, upload backup to s3 bucket and stream files from s3 bucket to the elastio vault.

--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -17,7 +17,7 @@ Script uses `rdsadmin.rdsadmin_rman_util` and `rdsadmin.rdsadmin_s3_tasks.upload
 ## Usage
 
 Copy the script to instance with next software instelled:
-- ssstar
+- `ssstar`
 - Oracle Instant Client including sqlplus
 - AWS CLI
 - `elastio` CLI

--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -20,7 +20,7 @@ Copy the script to instance with next software instelled:
 - ssstar
 - Oracle Instant Client including sqlplus
 - AWS CLI
-- Elastio CLI
+- `elastio` CLI
 
 Test connection to the Oracle RDS instans:
 ```

--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -16,7 +16,7 @@ Script uses `rdsadmin.rdsadmin_rman_util` and `rdsadmin.rdsadmin_s3_tasks.upload
 
 ## Usage
 
-Copy the script to instance with next software instelled:
+Copy the script to instance with next software installed:
 - `ssstar`
 - Oracle Instant Client including sqlplus
 - AWS CLI

--- a/elastio-oracle-rman-backup-ssstar-stream/README.md
+++ b/elastio-oracle-rman-backup-ssstar-stream/README.md
@@ -28,6 +28,16 @@ sqlplus username/password@aws-rds-hostname:1521/SID
 ```
 Make sure Elastio CLI is configured and has connection to the Elastio vault.
 
-Change script variables (Oracle DB credentials, s3 bucket name) according to your environment configuration and run script.
+Change script variables (Oracle DB credentials, s3 bucket name) according to your environment configuration and run script:
+```
+oracleDbUser='admin'
+oracleDbPassword='password'
+oracleDbHostname='database1.cd4xq5de693v.us-east-2.rds.amazonaws.com'
+oracleDbPort='1521'
+oracleDbSID='ORCL'
+
+s3BucketName='oracle2291'
+oracleBackupDir='DATA_PUMP_DIR'
+```
 
 Script will create Oracle backup, upload backup to s3 bucket and stream files from s3 bucket to the elastio vault.

--- a/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
+++ b/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
@@ -6,9 +6,10 @@ oracleDbHostname='database1.cd4xq5de693v.us-east-2.rds.amazonaws.com'
 oracleDbPort='1521'
 oracleDbSID='ORCL'
 
-s3BucketName='oracle2291'
+s3BucketName='oraclebackup2291'
 oracleBackupDir='DATA_PUMP_DIR'
 
+#Execute Oracle backup and s3 upload script via sqlplus
 sqlplus $oracleDbUser/$oracleDbPassword@$oracleDbHostname:$oracleDbPort/$oracleDbSID <<EOF
 DECLARE 
 V_TASKID VARCHAR2(100);
@@ -44,5 +45,6 @@ END;
 /
 EOF
 
+#Stream archive from s3 to elastio via ssstar
 ssstar create s3://$s3BucketName --stdout \
   | elastio stream backup --hostname-override $oracleDbHostname --stream-name $oracleDbSID

--- a/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
+++ b/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+oracleDbUser='admin'
+oracleDbPassword='password'
+oracleDbHostname='database1.cd4xq5de693v.us-east-2.rds.amazonaws.com'
+oracleDbPort='1521'
+oracleDbSID='ORCL'
+
+s3BucketName='oracle2291'
+oracleBackupDir='BKP02'
+
+sqlplus $oracleDbUser/$oracleDbPassword@$oracleDbHostname:$oracleDbPort/$oracleDbSID <<EOF
+DECLARE 
+V_TASKID VARCHAR2(100);
+V_COUNT integer := 0;
+V_LOG integer := 0;
+
+BEGIN
+/*Run full database backup*/
+rdsadmin.rdsadmin_rman_util.backup_database_full(
+        p_owner               => 'SYS', 
+        p_directory_name      => '$oracleBackupDir',
+        p_section_size_mb     => 2000);
+
+/*Upload backup to s3 bucket*/
+SELECT rdsadmin.rdsadmin_s3_tasks.upload_to_s3(
+		p_bucket_name => '$s3BucketName',  
+		p_directory_name => '$oracleBackupDir') 
+INTO V_TASKID FROM DUAL;
+
+/*Wait till log file with upload progress is created*/
+WHILE V_LOG = 0 LOOP 
+SELECT COUNT(1) INTO V_LOG FROM TABLE(rdsadmin.rds_file_util.listdir(p_directory=>'BDUMP')) 
+WHERE filename='dbtask-'|| V_TASKID ||'.log';
+END LOOP;
+
+/*Wait till upload is completed*/
+WHILE V_COUNT = 0 LOOP
+SELECT count(*) INTO V_COUNT FROM table(rdsadmin.rds_file_util.read_text_file('BDUMP', 'dbtask-'|| V_TASKID ||'.log')) 
+WHERE text LIKE '%finished successfully%';
+END LOOP;
+
+END;
+/
+EOF
+
+ssstar create s3://$s3BucketName --stdout \
+  | elastio stream backup --hostname-override $oracleDbHostname --stream-name $oracleDbSID

--- a/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
+++ b/elastio-oracle-rman-backup-ssstar-stream/elastio-oracle-rman-backup-ssstar-stream.sh
@@ -7,7 +7,7 @@ oracleDbPort='1521'
 oracleDbSID='ORCL'
 
 s3BucketName='oracle2291'
-oracleBackupDir='BKP02'
+oracleBackupDir='DATA_PUMP_DIR'
 
 sqlplus $oracleDbUser/$oracleDbPassword@$oracleDbHostname:$oracleDbPort/$oracleDbSID <<EOF
 DECLARE 


### PR DESCRIPTION
Example script to initiate RMAN oracle backup, monitoring s3 upload process and stream files from s3 to the vault using ssstar. 