### PR TITLE
Refactor and simplify AWS Backup integration docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,22 @@
 .history/
 
 *.vsix
-demo-pipeline/terraform/.terraform.lock.hcl
+
+# Terraform local state
+*.tfstate
+*.tfstate*.backup
+
+# File with ad-hoc input values to simplify invoking terraform with same inputs multiple times
+terraform.tfvars
+
+# Terraform plugins dir
+.terraform
+
+# Terraform file lock
+.terraform.tfstate.lock
+.terraform.tfstate.lock.info
+
+# Usually, lock files are committed to VCS, but the goal of this repo is to have low overhead.
+# Lock files are needed to have reproducible deployments in real scenarios. We don't need
+# that in this repo, because our terraform projects are exemplary, and unlikely to break.
+.terraform.lock.hcl

--- a/elastio-aws-backup-eventbridge-iscan-report/eventbridge-sqs.tf
+++ b/elastio-aws-backup-eventbridge-iscan-report/eventbridge-sqs.tf
@@ -1,0 +1,46 @@
+# This will use the `default` AWS CLI profile
+provider "aws" {}
+
+resource "aws_cloudwatch_event_bus" "this" {
+  name = "elastio-iscan"
+  tags = {
+    # ⚠️ This tag is important to grant Elastio write access to the bus
+    "elastio:iscan-event-bus" = "true"
+  }
+}
+
+# Define the SQS queue that will receive the events from the EventBridge bus
+resource "aws_sqs_queue" "this" {
+  name = "elastio-iscan-receiver"
+}
+
+# Allow EventBridge to write to the SQS queue
+resource "aws_sqs_queue_policy" "allow_event_bridge_write_to_sqs" {
+  policy    = data.aws_iam_policy_document.allow_event_bridge_write_to_sqs.json
+  queue_url = aws_sqs_queue.this.id
+}
+
+data "aws_iam_policy_document" "allow_event_bridge_write_to_sqs" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.this.arn]
+  }
+}
+
+# Configure EventBridge to send events to the SQS queue
+resource "aws_cloudwatch_event_target" "sqs" {
+  rule           = aws_cloudwatch_event_rule.this.name
+  arn            = aws_sqs_queue.this.arn
+  event_bus_name = aws_cloudwatch_event_bus.this.name
+}
+
+resource "aws_cloudwatch_event_rule" "this" {
+  name           = "elastio-iscan"
+  event_pattern  = jsonencode({ source = ["elastio.iscan"] })
+  event_bus_name = aws_cloudwatch_event_bus.this.name
+}


### PR DESCRIPTION
[Rendered](https://github.com/elastio/contrib/tree/feat/refactor-aws-backup-integration-docs/elastio-aws-backup-eventbridge-iscan-report)

This is in response to the user feedback.

- Removed SQS from the main terraform config file example
- Moved the SQS deployment terraform project to a separate file
- Added the `tf` language tag to the fenced code block to enable syntax highlighting
- Made it clear that deploying the SQS queue is optional 
- Improved overall grammar and added more explicitness to the docs

# Testing

Manually deployed the terraform example stack in my AWS account