### PR TITLE
Move the demo recording of the API for EventBridge integration

### DIFF
--- a/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
+++ b/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
@@ -35,12 +35,12 @@ The function accepts JSON input in the following format:
 
         // Name of the event bus iscan reports will be written to.
         //
-        // If absent or `null`, then the value from `/elastio/iscan-results-eventbridge-bus`
+        // Optional. If absent or `null`, then the value from `/elastio/iscan-results-eventbridge-bus`
         // SSM parameter will be used. If the SSM parameter isn't set, then the "Default"
         // event bus will be used as the final fallback.
         //
         // To specify the default event bus explicitly, a "Default" string may be passed.
-        "event_bridge_bus": "MyBusName",
+        "event_bridge_bus": "MyBusName"
     }
 }
 ```
@@ -109,6 +109,11 @@ OR
 ```
 
 ## Examples
+
+### Demo
+
+Here is a short demo recording of using and testing the API:
+![image](https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4)
 
 ### Success
 

--- a/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
+++ b/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
@@ -110,12 +110,6 @@ OR
 
 ## Examples
 
-### Demo
-
-Here is a short demo recording of using and testing the API:
-
-https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4
-
 ### Success
 
 <details>
@@ -255,3 +249,9 @@ $ aws lambda invoke --function-name elastio-bg-jobs-service-aws-backup-rp-import
 ```
 
 </details>
+
+### Demo
+
+Here is a short demo recording of using and testing the API. Don't forget to press the unmute button in the video player bellow.
+
+https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4

--- a/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
+++ b/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
@@ -113,7 +113,8 @@ OR
 ### Demo
 
 Here is a short demo recording of using and testing the API:
-![image](https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4)
+
+https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4
 
 ### Success
 

--- a/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
+++ b/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
@@ -254,4 +254,4 @@ $ aws lambda invoke --function-name elastio-bg-jobs-service-aws-backup-rp-import
 
 Here is a short demo recording of using and testing the API. Don't forget to press the unmute button in the video player below.
 
-![video](https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4)
+https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4

--- a/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
+++ b/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md
@@ -252,6 +252,6 @@ $ aws lambda invoke --function-name elastio-bg-jobs-service-aws-backup-rp-import
 
 ### Demo
 
-Here is a short demo recording of using and testing the API. Don't forget to press the unmute button in the video player bellow.
+Here is a short demo recording of using and testing the API. Don't forget to press the unmute button in the video player below.
 
-https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4
+![video](https://user-images.githubusercontent.com/36276403/211019809-ac50528b-711c-45a2-b135-2b7aa1592851.mp4)


### PR DESCRIPTION
[Rendered](https://github.com/elastio/contrib/blob/feat/api-demo/elastio-aws-backup-eventbridge-iscan-report/elastio-lambda-api.md)

This a 2.5 minute video showcasing how the API can be used copied from [the gist](https://gist.github.com/anelson/4fbd893dc1ebd859622e90d0c61b8c25?permalink_comment_id=4381663#gistcomment-4381663) into the media hosting issue https://github.com/elastio/contrib/issues/37