### PR TITLE
Velero restore script for 0.28

### DIFF
--- a/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
+++ b/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
@@ -101,7 +101,7 @@ RPs=($(elastio rp list --limit 1000 --tag velero.io/backup=$veleroBackupName | g
 if [ ! -z "$RPs" ];
 then
   echo
-  echo $(date)": Found elastio recovery points:"
+  echo $(date)": Found elastio recovery points with velero backup $veleroBackupName and namespace $namespaceName in AWS:"
   r=0
   for RP in ${RPs[*]}
   do
@@ -124,6 +124,7 @@ echo
 
 for backup in $(cat temp.json  | jq .[] -c)
 do
+  echo -ne "."
   #for each volume in the velero backup get volume and snapshot ids
   snapshot=$(echo $backup | jq .status.providerSnapshotID -r)
   volume=$(echo $backup | jq .spec.providerVolumeID -r)

--- a/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
+++ b/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
@@ -101,7 +101,7 @@ RPs=($(elastio rp list --limit 1000 --tag velero.io/backup=$veleroBackupName | g
 if [ ! -z "$RPs" ];
 then
   echo
-  echo $(date)": Found elastio recovery points with velero backup $veleroBackupName and namespace $namespaceName in AWS:"
+  echo $(date)": Found elastio recovery points with velero backup $veleroBackupName and namespace $namespaceName:"
   r=0
   for RP in ${RPs[*]}
   do
@@ -159,17 +159,20 @@ do
   fi
 done
 
-sleep 60
+sleep 30
 
 if [ "$(elastio job list --output-format json --kind restore)" != "[]" ];
 then
+echo
+echo
 echo $(date)": EBS restore is in progress, the duration will depend on the data size."
+echo
 fi
 
 #wait restore to finish
 while [[ $(elastio job list --output-format json --kind restore) != "[]" ]]
 do
-  sleep 60
+  sleep 30
   echo -ne "."
 done
 

--- a/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
+++ b/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
@@ -161,7 +161,7 @@ done
 
 sleep 60
 
-if [ $(elastio job list --output-format json --kind restore) != "[]" ];
+if [ "$(elastio job list --output-format json --kind restore)" != "[]" ];
 then
 echo $(date)": EBS restore is in progress, the duration will depend on the data size."
 fi

--- a/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
+++ b/elastio-velero-integration/restore-snapshots-with-velero-backups.sh
@@ -85,48 +85,85 @@ fi
 if [ ! -z "$(aws ec2 describe-snapshots --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName --query "Snapshots[].SnapshotId" --output text)" ];
 then
   echo
-  echo "Cannot proceed. Script is designed to restore entire namespace from a given backup. Snapshots with velero backup $veleroBackupName and namespace $namespaceName are present in AWS:"
+  echo $(date)": Found snapshots with velero backup $veleroBackupName and namespace $namespaceName in AWS:"
   s=0
   for snapshotID in $(aws ec2 describe-snapshots --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName --query "Snapshots[].SnapshotId" --output text)
   do
     ((s++))
     echo $s. $snapshotID
+	var=$(aws ec2 delete-tags --resources $snapshotID --tags Key=elastio:imported-to-rp 2>&1)
+	var=$(aws ec2 create-tags --resources $snapshotID --tags Key=elastio:velero,Value=true 2>&1)
   done
-  exit
 fi
 
 #get RPs by namespace and velero backup name
 RPs=($(elastio rp list --limit 1000 --tag velero.io/backup=$veleroBackupName | grep namespace=$namespaceName | grep -oP rp-[A-Za-z0-9]+))
-
-#exit if RPs not found
-if [ -z "$RPs" ];
+if [ ! -z "$RPs" ];
 then
   echo
-  echo "No elastio recovery points matching your request were found. Make sure namespace and velero backup name are correct."
-  echo
-  exit
+  echo $(date)": Found elastio recovery points:"
+  r=0
+  for RP in ${RPs[*]}
+  do
+    ((r++))
+    echo $r. $RP
+  done
 fi
 
-echo
-echo $(date)": Found elastio recovery points:"
-r=0
-for RP in ${RPs[*]}
-do
-  ((r++))
-  echo $r. $RP
-done
+#download velero config file from s3
+var=$(aws s3 cp s3://$veleroS3Bucket/backups/$veleroBackupName/$veleroBackupName-volumesnapshots.json.gz ./temp.json.gz 2>&1)
 
-#run restore of RPs
-for RP in ${RPs[*]}
-do
-  sleep 2
-  var=$(elastio ebs restore --rp $RP --restore-asset-tags 2>&1)
-done
+#upload a backup of config to s3
+var=$(aws s3 cp ./temp.json.gz s3://$veleroS3Bucket/backups/$veleroBackupName/$veleroBackupName-volumesnapshots-original-$(date +%s).json.gz 2>&1)
+
+gzip -d temp.json.gz
 
 echo
-echo $(date)": EBS restore is in progress, the duration will depend on the data size."
+echo $(date)": Working with snashots list of the $veleroBackupName velero backup."
+echo
+
+for backup in $(cat temp.json  | jq .[] -c)
+do
+  #for each volume in the velero backup get volume and snapshot ids
+  snapshot=$(echo $backup | jq .status.providerSnapshotID -r)
+  volume=$(echo $backup | jq .spec.providerVolumeID -r)
+  if [ "$snapshot" != "null" ]
+  then
+    #check if snapshot is still present in the aws
+    snapshotinaws=$(aws ec2 describe-snapshots --snapshot-ids $snapshot --query "Snapshots[].SnapshotId" --output text 2>/dev/null)
+    #if snapshot not present in aws check elastio rps
+    if [ -z "$snapshotinaws" ];
+    then
+      elastiorp=$(elastio rp list --ebs $volume --tag velero.io/backup=$veleroBackupName 2>/dev/null)
+      if [ -z "$elastiorp" ];
+      then
+        echo "ERROR: elastio recovery point of snapshot $snapshot for velero backup $veleroBackupName is missing. This might affect velero restore."
+      fi
+      if [ ! -z "$elastiorp" ];
+      then
+        elastiorpid=$(echo $elastiorp | grep -oP rp-[A-Za-z0-9]+)
+        nanesmace=$(echo $elastiorp | grep -oP $namespaceName)
+        #if elastio rp has a tag with given namespace start restore
+        if [ "$nanesmace" = "$namespaceName" ]
+    	then
+    	  var=$(elastio ebs restore --rp $elastiorpid --restore-asset-tags --restore-snapshots --tag elastio:velero=true 2>&1)
+    	fi
+      fi
+    fi
+  fi
+  #some backups has failed snapshot status, nothing we can do here
+  if [ "$snapshot" = "null" ]
+  then
+    echo "Velero backup $veleroBackupName is missing snapshot for volume $volume. This might affect velero restore."
+  fi
+done
 
 sleep 60
+
+if [ $(elastio job list --output-format json --kind restore) != "[]" ];
+then
+echo $(date)": EBS restore is in progress, the duration will depend on the data size."
+fi
 
 #wait restore to finish
 while [[ $(elastio job list --output-format json --kind restore) != "[]" ]]
@@ -135,51 +172,14 @@ do
   echo -ne "."
 done
 
-#create snapshots with velero tags
-for volumeID in $(aws ec2 describe-volumes --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName --query "Volumes[].VolumeId" --output text)
-do
-  volumeTags=$(aws ec2 describe-volumes --volume-ids $volumeID | jq ".Volumes[0].Tags" | sed -r 's/"+//g' | sed -r 's/: +/=/g')
-  snapshotID=$(aws ec2 create-snapshot --volume-id $volumeID --tag-specifications "ResourceType=snapshot,Tags=$volumeTags" --query "SnapshotId" --output text)
-  sleep 5
-  var=$(aws ec2 create-tags --resources $snapshotID --tags Key=elastio:nobackup,Value=true 2>&1)
-done
-
 echo
-echo $(date)": EBS restore is completed."
-echo
-echo $(date)": Creating EBS snapshot(s), the duration will depend on the data size."
-
-#wait snapshot creation finish and remove EBS
-for snapshotID in $(aws ec2 describe-snapshots --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName Name=tag:elastio:restored-from-rp,Values=* Name=tag:elastio:nobackup,Values=true --query "Snapshots[].SnapshotId" --output text)
-do
-  while [[ $(aws ec2 describe-snapshots --snapshot-ids $snapshotID --query "Snapshots[].State" --output text) != "completed" ]]
-  do
-    sleep 60
-    echo -ne "."
-  done
-  aws ec2 delete-volume --volume-id $(aws ec2 describe-snapshots --snapshot-ids $snapshotID --query "Snapshots[].VolumeId" --output text)
-done
-
-echo
-echo $(date)": Snapshot(s) created:"
+echo $(date)": Snapshot(s) available for the velero restore:"
 s=0
-for snapshotID in $(aws ec2 describe-snapshots --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName Name=tag:elastio:restored-from-rp,Values=* Name=tag:elastio:nobackup,Values=true --query "Snapshots[].SnapshotId" --output text)
+for snapshotID in $(aws ec2 describe-snapshots --filters Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName Name=tag:elastio:velero,Values=true --query "Snapshots[].SnapshotId" --output text)
 do
   ((s++))
   echo $s. $snapshotID
 done
-
-echo
-
-#download velero config file from s3
-aws s3 cp s3://$veleroS3Bucket/backups/$veleroBackupName/$veleroBackupName-volumesnapshots.json.gz ./temp.json.gz
-
-echo
-
-#upload a backup of config to s3
-aws s3 cp ./temp.json.gz s3://$veleroS3Bucket/backups/$veleroBackupName/$veleroBackupName-volumesnapshots-original-$(date +%s).json.gz
-
-gzip -d temp.json.gz
 
 echo
 echo $(date)": Updating Velero configuration file."
@@ -190,7 +190,7 @@ declare -i v=0
 
 for volumeID in $(cat temp.json | jq .[].spec.providerVolumeID -r)
 do
-  snapshotID=$(aws ec2 describe-snapshots --filters Name=tag:elastio:restored-from-asset,Values=$volumeID Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName Name=tag:elastio:nobackup,Values=true --query "Snapshots[].SnapshotId" --output text)
+  snapshotID=$(aws ec2 describe-snapshots --filters Name=tag:elastio:restored-from-asset,Values=$volumeID Name=tag:velero.io/backup,Values=$veleroBackupName Name=tag:kubernetes.io/created-for/pvc/namespace,Values=$namespaceName Name=tag:elastio:velero,Values=true --query "Snapshots[].SnapshotId" --output text)
   echo -ne "."
   if [ ! -z "$snapshotID" ];
   then


### PR DESCRIPTION
The script logic is changed. I noticed in some velero backups that there are unsuccessful volume, meaning there are no snapshots for them. But those velero backups are still counted as valid. Probably partly valid or similar status. That's is why script is changed to run no matter what. 

Script has the following logic:
Get a list of snapshots ids and their volume ids from s3 bucket with velero backups 
Go through the list.
If snapshot was not created during backup show warning: `Velero backup $veleroBackupName is missing snapshot for volume $volume. This might affect velero restore.`
If snapshot is not present in AWS do elastio rp list. If k8s namespace of the snapshot matches run a restore. If not show error and continue: `ERROR: elastio recovery point of snapshot $snapshot for velero backup $veleroBackupName is missing. This might affect velero restore.` 

Example of the script output:
```./restore-snapshots-with-velero-backups.sh  -n saas01so -b staging-us-east-1-daily-backup-2023121607
0012 -s turbonomic-saas-backup-staging -r us-east-1

Wed Jan 10 14:32:11 UTC 2024: Found elastio recovery points with velero backup staging-us-east-1-daily-backup-20231216070012 and namespace saas01so:
1. rp-01hht0ekm3kghmr8kbpdyneayg
2. rp-01hhthwwb5r55erd64ct5fvc86
3. rp-01hhva3hdw3cspnwjw9cznsttt
4. rp-01hhsqsfr6hvw1zm3jaew4kqds
5. rp-01hhs42f5454a01wv2pv79xn9e
6. rp-01hhxjk9z0s96xpv2v5s62pvtt
7. rp-01hhsxjpavz9ng5jannaqavxjd
8. rp-01hjw1krbr914g66w96d58vzfj
9. rp-01hhssraf2h2hgeqp0rmq6v0tz
10. rp-01hhxpgvww6ee0fz8hj2xbaa4t
11. rp-01hhw1ah1vvcrjtt19xs34waec
12. rp-01hht5jyr4ynegc77kt5gdmnfq

Wed Jan 10 14:32:12 UTC 2024: Working with snashots list of the staging-us-east-1-daily-backup-20231216070012 velero backup.

................................................................................................................................................................

Wed Jan 10 14:39:37 UTC 2024: EBS restore is in progress, the duration will depend on the data size.

.......................................................................................................................

Wed Jan 10 15:55:49 UTC 2024: Snapshot(s) available for the velero restore:
1. snap-0ffefedbf86807939
2. snap-0abd4aa828f7c5b88
3. snap-05756c7767aa6e195
4. snap-063a5073dbb2ad530
5. snap-06908a9dba6bcf0ef
6. snap-04f9d7dcd95e08476
7. snap-05ab3388f1f788ce4
8. snap-0867c7d9b5103b7b4
9. snap-02d8ff5e7dd720755
10. snap-01d33da5e32a3eaa0
11. snap-07d78410534b36536
12. snap-05e956a4dcffe611e

Wed Jan 10 15:55:50 UTC 2024: Updating Velero configuration file.

................................................................................................................................................................

Wed Jan 10 15:58:33 UTC 2024: Snapshots of velero backup staging-us-east-1-daily-backup-20231216070012 are restored. Please proceed with restore via velero CLI.
```