### PR TITLE
Add a new folder with a reference VPC and some documentation.

### DIFF
--- a/elastio-vpc-sample/README.md
+++ b/elastio-vpc-sample/README.md
@@ -1,0 +1,49 @@
+# Elastio Sample VPC
+
+This Cloudformation template provides a reference VPC example, which has been properly configured for use with Elastio.
+
+Elastio does not require a dedicated VPC, and is designed to be able to use the VPCs, subnets, and other network resources that customers already have in their infrastructure.  However it does require that each subnet into which Elastio is deployed be able to access the Internet, either directly via an Internet gateway, indirectly via a NAT gateway, or via some customer-specific network topology that routes through a transit gateway, on-prem network, third-party firewall, or some other means.  No matter what the network topology, Elastio worker instances must be able to reach the specific URLs that are required for Elastio to function, which include (but are not limited to):
+
+- All AWS API endpoints (which all have DNS names ending in `amazonaws.com`)
+- The ECR Public container registry at `public.ecr.aws`
+- CDN endpoints used by Elastio iScan for malware and ransomware definitions.
+
+For a current list of all URLs Elastio must access, see the [troubleshooting section of the Elastio docs](https://docs.elastio.com/docs/reference/troubleshooting#adding-urls-accessed-by-elastio-to-the-whitelist).
+
+The above notwithstanding, many customers are unsure how exactly a VPC must be configured for compatibility with Elastio and adherence to best practices.  This Cloudformation template provides a quick and easy way to deploy a VPC that is pre-qualified by Elastio for compatibility.  Customers can then modify this VPC to fit their policies, or adjust the Cloudformation template itself as needed.
+
+For help determining if an existing VPC is suitable for use with Elastio, or if it's not working to determine why not, see also the [Elastio VPC reachability script](../vpc-reachability-analyzer/).
+
+## What This Sample Does
+
+This Cloudformation template will create a new VPC, with three private subnets spread across three availability zones, and one public subnet.  Each private subnet will have access to the Internet via a single, shared NAT gateway located in the single public subnet.  An Internet gateway is also deployed in the public subnet to provide a route to the Internet for the NAT gateway.  Each of the subnets has a `/20` CIDR, providing approximately 4000 usable IP addresses per subnet.  This is more than enough for Elastio's needs (although a `/24` with 254 usable IP addresses might not be enough for large customers running hundreds of jobs in parallel, which is why by default we use a `/20`).
+
+## How Much Will This Sample Cost
+
+Most of the resources deployed in this sample are free.  One important exception is that NAT gateway.  Always refer to the [official AWS VPC Pricing](https://aws.amazon.com/vpc/pricing/) for the latest information, but as of this writing in the US regions, a single NAT gateway costs $0.045/hr, plus $0.045/GB of traffic.  This comes out to $32.40/mo plus whatever the traffic cost is.
+
+Due to the way Elastio works, the majority of traffic Elastio generates is to or from S3.  Since this template deploys an S3 gateway VPC endpoint, all S3 traffic will bypass the NAT gateway and go directly to S3, so in most cases the volume of traffic over the NAT gateway will be low, but it's not possible to predict how much it will be and thus how much it will cost.  In all but the most extreme cases, the cost of the NAT gateway including Elastio-generated traffic should be well under $100/mo.
+
+Another variable cost to this VPC is the cross-AZ traffic.  Precisely because the NAT gateways are not free, we have chosen to deploy a single NAT gateway in a single availability zone, with the two other private subnets routing their Internet traffic across AZ boundaries to the AZ housing the NAT gateway.  As of this writing, the [AWS in-region data transfer pricing](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer_within_the_same_AWS_Region) for cross-AZ traffic is $0.02/GB ($0.01 for traffic leaving one AZ and $0.01 for that same traffic entering the destination AZ).  This means that traffic to the Internet originating in the second or third subnet will incur cross-AZ bandwidth charges as well as NAT gateway bandwidth charges.  S3 traffic is exempt from this due to the use of S3 gateway VPC endpoints.  This is unlikely to be a significant amount of traffic under normal Elastio usage scenarios, but we call it out here nonetheless in the interest of completeness.
+
+## How to Deploy This Sample
+
+To deploy this sample, you must first download the Cloudformation template locally.  To do that, right-click this [download Cloudformation template](https://github.com/elastio/contrib/blob/master/elastio-vpc-sample/elastio-sample-vpc-template.yaml) link, and choose "Save Link As" or whatever your browser's equivalent is, choosing to save this file in some directory (often the `Downloads`) directory.  Make a note of where you saved it, as that will be important later.
+
+Next, log in to the AWS console in the account where you want to create the VPC.  Go to the Cloudformation console, and make sure you are in the region where you want the VPC deployed.
+
+From the Cloudformation console, click **Create Stack**.  The default option **Template is ready** should be selected.  For _Template Source_, choose the option **Upload a template file**, then click the _Choose File_ button and browse to the `elastio-sample-vpc-template.yaml` file you downloaded earlier, and then click **Next**.
+
+Choose a stack name for this Cloudformation stack.  Any name will work; for example `elastio-vpc`.
+
+Next review the **Parameters** section to see the options that you can specify to the Cloudformation template to control the resulting VPC.  If your company has naming conventions that require certain prefixes or suffixes, you can enter those separately for VPC and subnet-level resources in the parameters `VpcPrefix/VpcSuffix` and `SubnetPrefix/SubnetSuffix`, respectively.  You're also able to control the private network CIDR block used by the VPC, although unless you have a specific reason to change these and know what you are doing we recommend you accept the defaults.
+
+When you are satisfied with the Parameters, click **Next**
+
+On the next screen you can add any tags that you like, particularly if your organization has rules requiring particular tags on stacks or the resources they create.
+
+Otherwise, scroll down past the other stack options, leaving everything set to default, and click **Next**.
+
+On the last screen, accept all defaults, scroll all the way down, and click **Submit**.
+
+The stack will take a minute or two to deploy, at which point you should have a new VPC, subnets, and other resources that you can use with Elastio.

--- a/elastio-vpc-sample/elastio-sample-vpc-template.yaml
+++ b/elastio-vpc-sample/elastio-sample-vpc-template.yaml
@@ -1,0 +1,241 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  This CloudFormation template creates a VPC with three private subnets across
+  three availability zones, a NAT gateway, and an S3 gateway endpoint. It allows
+  users to set custom names for the VPC and its subnets through parameters with
+  default values set to empty strings.
+
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: 'Network CIDR options'
+        Parameters:
+          - VpcCidr
+          - PublicSubnetCidr
+          - PrivateSubnet1Cidr
+          - PrivateSubnet2Cidr
+          - PrivateSubnet3Cidr
+      - Label:
+          default: 'Network name customization options'
+        Parameters:
+          - VpcPrefix
+          - VpcSuffix
+          - SubnetPrefix
+          - SubnetSuffix
+
+Parameters:
+  VpcPrefix:
+    Type: String
+    Default: ''
+    Description: (Optional) The prefix to use for naming the VPC and VPC-specific resources. Leave blank for no prefix.  Note all resources will have a name starting with `Elastio`, so there is no need to specify Elastio here.
+  VpcSuffix:
+    Type: String
+    Default: ''
+    Description: (Optional) The suffix to use for naming the VPC and VPC-specific resources. Leave blank for no prefix.  Note all resources will have a name starting with `Elastio`, so there is no need to specify Elastio here.
+  SubnetPrefix:
+    Type: String
+    Default: ''
+    Description: (Optional) The prefix to use for naming the subnets and subnet-specific resources. Leave blank for no prefix.  Note all resources will have a name starting with `Elastio`, so there is no need to specify Elastio here.
+  SubnetSuffix:
+    Type: String
+    Default: ''
+    Description: (Optional) The suffix to use for naming the subnets and subnet-specific resources. Leave blank for no prefix.  Note all resources will have a name starting with `Elastio`, so there is no need to specify Elastio here.
+
+  VpcCidr:
+    Type: String
+    Default: '10.0.0.0/16'
+    Description: The CIDR block for the Elastio VPC.
+  PublicSubnetCidr:
+    Type: String
+    Default: '10.0.0.0/20'
+    Description: The CIDR block for the public subnet where the NAT Gateway will be located.
+  PrivateSubnet1Cidr:
+    Type: String
+    Default: '10.0.16.0/20'
+    Description: The CIDR block for the first private subnet.  Make sure it is large enough to provide IP addresses to all worker nodes.
+  PrivateSubnet2Cidr:
+    Type: String
+    Default: '10.0.32.0/20'
+    Description: The CIDR block for the second private subnet.  Make sure it is large enough to provide IP addresses to all worker nodes.
+  PrivateSubnet3Cidr:
+    Type: String
+    Default: '10.0.48.0/20'
+    Description: The CIDR block for the third private subnet.  Make sure it is large enough to provide IP addresses to all worker nodes.
+
+Resources:
+  ElastioVPC:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      # The name tag for the VPC, using the custom parameters provided.
+      Tags:
+        - Key: Name
+          Value: !Sub '${VpcPrefix}Elastio${VpcSuffix}'
+
+  InternetGateway:
+    Type: 'AWS::EC2::InternetGateway'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub '${VpcPrefix}ElastioInternetGateway${VpcSuffix}'
+
+  AttachGateway:
+    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Properties:
+      VpcId: !Ref ElastioVPC
+      InternetGatewayId: !Ref InternetGateway
+
+  NatGatewayEIP:
+    Type: 'AWS::EC2::EIP'
+    Properties:
+      # EIP needs to be in the public subnet to assist the NAT gateway.
+      Domain: vpc
+
+  NatGateway:
+    Type: 'AWS::EC2::NatGateway'
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      AllocationId: !GetAtt NatGatewayEIP.AllocationId
+      Tags:
+        - Key: Name
+          Value: !Sub '${VpcPrefix}ElastioNatGateway${VpcSuffix}'
+
+  PublicSubnet:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref ElastioVPC
+      CidrBlock: !Ref PublicSubnetCidr
+      MapPublicIpOnLaunch: true
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPublicSubnet${SubnetSuffix}'
+
+  # Create a route table for the public subnet
+  PublicRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref ElastioVPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPublicRouteTable${SubnetSuffix}'
+
+  # Create a route in the public route table to the internet gateway
+  PublicRoute:
+    Type: 'AWS::EC2::Route'
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway
+
+  # Associate the public route table with the public subnet
+  PublicSubnetRouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+
+  # Creation of three private subnets, one in each availability zone
+  PrivateSubnet1:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref ElastioVPC 
+      CidrBlock: !Ref PrivateSubnet1Cidr
+      # MapPublicIpOnLaunch is set to false to make this a private subnet.
+      MapPublicIpOnLaunch: false
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPrivateSubnet1${SubnetSuffix}'
+
+  PrivateSubnet2:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref ElastioVPC 
+      CidrBlock: !Ref PrivateSubnet2Cidr
+      # MapPublicIpOnLaunch is set to false to make this a private subnet.
+      MapPublicIpOnLaunch: false
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPrivateSubnet2${SubnetSuffix}'
+
+  PrivateSubnet3:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref ElastioVPC 
+      CidrBlock: !Ref PrivateSubnet3Cidr
+      # MapPublicIpOnLaunch is set to false to make this a private subnet.
+      MapPublicIpOnLaunch: false
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPrivateSubnet3${SubnetSuffix}'
+
+  # Each subnet must have a route table associated with it.
+  # This is the route table for the private subnets:
+  PrivateRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref ElastioVPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${SubnetPrefix}ElastioPrivateRouteTable${SubnetSuffix}'
+
+  # A route in the private route table that points all traffic (0.0.0.0/0) to the NAT Gateway
+  PrivateRoute:
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId: !Ref NatGateway
+
+  # Associate the private route table with each of the private subnets
+  PrivateSubnet1RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnet2RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnet3RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateRouteTable
+
+  # AWS S3 Gateway endpoint applicable to all subnets within the VPC
+  #
+  # This is important to ensure that Elastio's S3 traffic routes through the free S3 gateway endpoint,
+  # and not the very expensive NAT gateway.
+  S3VPCEndpoint:
+    Type: 'AWS::EC2::VPCEndpoint'
+    Properties:
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
+      VpcId: !Ref ElastioVPC
+      # Indicating the endpoint is for a Gateway (as opposed to an Interface)
+      VpcEndpointType: Gateway
+      # Specifying which route tables to associate the endpoint with
+      RouteTableIds:
+        - !Ref PrivateRouteTable
+        - !Ref PublicRouteTable
+      # There can be more route tables if public subnets or other route tables are defined
+
+Outputs:
+  VpcId:
+    Description: "The ID of the new VPC"
+    Value: !Ref ElastioVPC
+  PublicSubnet:
+    Description: "The ID of the public subnet which contains the Internet and NAT gateways"
+    Value: !Ref PublicSubnet
+  PrivateSubnets:
+    Description: "List of the private subnet IDs"
+    Value: !Join [", ", [!Ref PrivateSubnet1, !Ref PrivateSubnet2, !Ref PrivateSubnet3]]


### PR DESCRIPTION
This was prompted by a request from a customer, but it's been something I've meant to prepare for a while.

This is an example of how a VPC would be configured if it were set up by us specifically for use with Elastio.  It's not the only way to create a VPC that works with Elastio, but unless you have some reason to do it differently, this should be the starting point.
