### PR TITLE
Create elastio-aws-snapshot-action-tag-integration-template.yaml

### DIFF
--- a/elastio-aws-snapshot-action-tag-integration/elastio-aws-snapshot-action-tag-integration-template.yaml
+++ b/elastio-aws-snapshot-action-tag-integration/elastio-aws-snapshot-action-tag-integration-template.yaml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'This stack deploys the components required to integrate AWS snapshots with Elastio'
+Parameters:
+  TagKeyToMonitor:
+    Description: The tag keys to monitor for in newly created EBS snapshots (comma-separated)
+    Type: String
+    Default: "cp:data, cp:host-snapshot-name"
+  ElastioActionTagValue:
+    Description: The value for the "elastio:action" tag to be added to snapshot. Possible values are scan, ingest, ingest-and-scan.
+    Type: String
+    Default: "scan"
+Resources:
+  LambdaExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "lambda.amazonaws.com"
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Policies:
+        - PolicyName: "ElastioSnapshotTaggingPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ec2:CreateTags"
+                  - "ec2:DescribeTags"
+                Resource: "*"
+
+  LambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Timeout: 120
+      Handler: "index.lambda_handler"
+      Runtime: python3.8
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          TagKeyToMonitor: !Ref TagKeyToMonitor
+          ElastioActionTagValue: !Ref ElastioActionTagValue
+      Code:
+        ZipFile: |
+          import boto3
+          import os
+
+          def lambda_handler(event, context):
+              response_elements = event.get('detail', {}).get('responseElements', {})
+              resource_id = response_elements.get('snapshotId')
+              
+              ec2_client = boto3.client('ec2')
+
+              snapshot_tags = ec2_client.describe_tags(Filters=[{'Name': 'resource-id', 'Values': [resource_id]}])['Tags']
+              
+              tag_key_to_monitor = os.environ.get('TagKeyToMonitor') 
+              elastio_action_tag_value = os.environ.get('ElastioActionTagValue') 
+              
+              tag_keys_to_monitor = [tag.strip() for tag in tag_key_to_monitor.split(',')]
+              
+              if any(tag['Key'] in tag_keys_to_monitor for tag in snapshot_tags):
+                  ec2_client.create_tags(Resources=[resource_id], Tags=[{'Key': 'elastio:action', 'Value': elastio_action_tag_value}])
+
+  CloudWatchEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      EventPattern:
+        source:
+          - "aws.ec2"
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventName:
+            - "CreateSnapshot"
+      Targets:
+        - Arn: !GetAtt LambdaFunction.Arn
+          Id: "TargetFunctionV1"
+  PermissionForEventsToInvokeLambda:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !GetAtt LambdaFunction.Arn
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CloudWatchEventRule.Arn


### PR DESCRIPTION
This CFN accepts 2 parameters:
 - elastio:action tag value (default scan)
 - aws snapshot tag key (default cp:data,  cp:host-snapshot-name)

And runs a function on snapshot creation which sets elastio:action tag on snapshot if it has specified tag

![image](https://github.com/elastio/contrib/assets/81738703/32ff5838-7890-46f3-b8da-a9bf8769b6ff)
