### PR TITLE
Add `EnableDql` parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,6 @@ jobs:
       needs.changes.outputs.ci == 'true'
     env:
       S3_BUCKET: elastio-prod-artifacts-us-east-2
-      S3_PREFIX: contrib
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -76,17 +75,5 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ vars.aws_elastio_prod_artifacts_contrib_role_arn }}
-      - name: Update version in template
-        run: |
-          version=$(cat elastio-s3-changelog/version)
-          echo "TEMPLATE_VERSION=${version}" >> "$GITHUB_ENV"
 
-          sed -i elastio-s3-changelog/*.yaml \
-            -e "s/{{REGION}}/${AWS_REGION}/g" \
-            -e "s/{{BUCKET}}/${S3_BUCKET}/g" \
-            -e "s/{{PREFIX}}/${S3_PREFIX}/g" \
-            -e "s/{{VERSION}}/${version}/g"
-      - name: Upload to S3
-        run: |
-          aws s3 cp --recursive ./elastio-s3-changelog \
-            "s3://${S3_BUCKET}/${S3_PREFIX}/${TEMPLATE_VERSION}/"
+      - run: ./elastio-s3-changelog/upload.sh

--- a/elastio-s3-changelog/README.md
+++ b/elastio-s3-changelog/README.md
@@ -12,23 +12,25 @@ Then, the Elastio `iscan` job reads those events to perform the scanning of new 
 1. First, you need to enable Amazon EventBridge for your S3 buckets by following these instructions:
     [Enabling Amazon EventBridge](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html).
 2. You can use
-    [this quick-create link](https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://elastio-prod-artifacts-us-east-2.s3.us-east-2.amazonaws.com/contrib/v1/cloudformation-multiple-buckets.yaml&stackName=elastio-s3-changelog)
+    [this quick-create link](https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://elastio-prod-artifacts-us-east-2.s3.us-east-2.amazonaws.com/contrib/elastio-s3-changelog/v1/cloudformation-multiple-buckets.yaml&stackName=elastio-s3-changelog)
     to create the stack.
 
     > You might need to switch to the region where your Elastio CloudFormation stack is deployed.
 
-    >**Important!** You can change the stack name, but it **MUST** start with `elastio-`. Otherwise, Elastio won't be able to access the created resources.
+    > **Important!** You can change the stack name, but it **MUST** start with `elastio-`. Otherwise, Elastio won't be able to access the created resources.
 
-3. Fill in the parameters:
+3. Fill in the main parameters:
     * *BucketNames* - comma-separated list of S3 bucket names;
+
     * *ScanExistingObjects* - set to `true` if you want to perform the initial scan of all objects in the bucket(s);
+
     * *KeyPrefixes* - comma-separated list of prefixes of objects to scan. This will be applied to all buckets.
         If you want to use different prefixes for different buckets, you need to deploy multiple S3 Changelog stacks.
-        Also note that the paths selector in the Protection Policy will also be used to filter objects before scanning.
+        Also, note that the paths selector in the Protection Policy will also be used to filter objects before scanning.
         This means that the *KeyPrefixes* parameter must be in sync with the paths selector in the Protection Policy,
         or not specified at all.
 
-    > There are also some experimental parameters in the template, you can ignore them.
+    > There are also some advanced and experimental parameters in the template, you can ignore them.
 
 4. Check the box in front of `I acknowledge that AWS CloudFormation might create IAM resources with custom names`
     and `I acknowledge that AWS CloudFormation might require the following capability: CAPABILITY_AUTO_EXPAND`

--- a/elastio-s3-changelog/cloudformation-multiple-buckets-with-macros.yaml
+++ b/elastio-s3-changelog/cloudformation-multiple-buckets-with-macros.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json
+
 # This file is not intended to be used on its own. It exists to work around a limitation in CloudFormation,
 # which prevents updating the CFN stack containing Fn::ForEach in the AWS console. This is because internally,
 # CFN stores the template after resolving macros, so changing the input parameters has no effect.
@@ -11,6 +13,9 @@ Parameters:
   ScanExistingObjects:
     Type: String
     Default: 'false'
+  EnableDlq:
+    Type: String
+    Default: 'true'
   EnableQrts:
     Type: String
     Default: 'false'
@@ -32,11 +37,12 @@ Resources:
           Parameters:
             BucketName: !Ref BucketName
             ScanExistingObjects: !Ref ScanExistingObjects
+            EnableDlq: !Ref EnableDlq
             EnableQrts: !Ref EnableQrts
             QrtsBatchSize: !Ref QrtsBatchSize
             QrtsMaxDelay: !Ref QrtsMaxDelay
             KeyPrefixes: !Ref KeyPrefixes
-          TemplateURL: https://{{BUCKET}}.s3.{{REGION}}.amazonaws.com/{{PREFIX}}/{{VERSION}}/cloudformation-single-bucket.yaml
+          TemplateURL: https://{{S3_BUCKET}}.s3.{{AWS_REGION}}.amazonaws.com/{{S3_PREFIX}}/{{VERSION}}/cloudformation-single-bucket.yaml
 Outputs:
   templateVersion:
     Value: "{{VERSION}}"

--- a/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
+++ b/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json
+
 # This template allows to enable the S3 changelog for multiple buckets.
 # It deploys one nested stack per bucket.
 AWSTemplateFormatVersion: "2010-09-09"
@@ -26,6 +28,14 @@ Parameters:
       Comma-delimited list of prefixes of objects to scan. Can be empty. Note that, unless QRTS (experimental)
       is enabled, paths selector in the Protection Policy will also be used to filter objects before scanning.
       Example: xyz/, foo/bar/
+
+  EnableDlq:
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'true'
+    Description: >
+      If set to true, enables the Dead Letter Queue (DLQ) for the changelog queue.
+      If set to false, disables the DLQ.
 
   EnableQrts:
     Type: String
@@ -61,6 +71,11 @@ Metadata:
           - BucketNames
           - ScanExistingObjects
           - KeyPrefixes
+
+      - Label: { default: Advanced Parameters }
+        Parameters:
+          - EnableDlq
+
       - Label: { default: "Experimental Parameters" }
         Parameters:
           - EnableQrts
@@ -74,11 +89,12 @@ Resources:
       Parameters:
         BucketNames: !Join [',', !Ref BucketNames]
         ScanExistingObjects: !Ref ScanExistingObjects
+        EnableDlq: !Ref EnableDlq
         EnableQrts: !Ref EnableQrts
         QrtsBatchSize: !Ref QrtsBatchSize
         QrtsMaxDelay: !Ref QrtsMaxDelay
         KeyPrefixes: !Join [',', !Ref KeyPrefixes]
-      TemplateURL: https://{{BUCKET}}.s3.{{REGION}}.amazonaws.com/{{PREFIX}}/{{VERSION}}/cloudformation-multiple-buckets-with-macros.yaml
+      TemplateURL: https://{{S3_BUCKET}}.s3.{{AWS_REGION}}.amazonaws.com/{{S3_PREFIX}}/{{VERSION}}/cloudformation-multiple-buckets-with-macros.yaml
 
 Outputs:
   templateVersion:

--- a/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
+++ b/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
@@ -66,7 +66,7 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label: { default: "Main Parameters" }
+      - Label: { default: Main Parameters }
         Parameters:
           - BucketNames
           - ScanExistingObjects
@@ -76,7 +76,7 @@ Metadata:
         Parameters:
           - EnableDlq
 
-      - Label: { default: "Experimental Parameters" }
+      - Label: { default: Experimental Parameters }
         Parameters:
           - EnableQrts
           - QrtsBatchSize

--- a/elastio-s3-changelog/cloudformation-single-bucket.yaml
+++ b/elastio-s3-changelog/cloudformation-single-bucket.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json
+
 # This template enables the S3 changelog for a single bucket.
 AWSTemplateFormatVersion: "2010-09-09"
 Parameters:
@@ -25,6 +27,14 @@ Parameters:
       Comma-delimited list of prefixes of objects to scan. Can be empty. Note that, unless QRTS (experimental)
       is enabled, paths selector in the Protection Policy will also be used to filter objects before scanning.
       Example: xyz/,foo/bar/
+
+  EnableDlq:
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'true'
+    Description: >
+      If set to true, enables the Dead Letter Queue (DLQ) for the changelog queue.
+      If set to false, disables the DLQ.
 
   EnableQrts:
     Type: String
@@ -55,12 +65,17 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label: { default: "Main Parameters" }
+      - Label: { default: Main Parameters }
         Parameters:
           - BucketName
           - ScanExistingObjects
           - KeyPrefixes
-      - Label: { default: "Experimental Parameters" }
+
+      - Label: { default: Advanced Parameters }
+        Parameters:
+          - EnableDlq
+
+      - Label: { default: Experimental Parameters }
         Parameters:
           - EnableQrts
           - QrtsBatchSize
@@ -68,6 +83,7 @@ Metadata:
 
 Conditions:
   ScanExistingObjects: !Equals [!Ref ScanExistingObjects, 'true']
+  EnableDlq: !Equals [!Ref EnableDlq, 'true']
   EnableQrts: !Equals [!Ref EnableQrts, 'true']
   NoKeyPrefixes: !Equals [!Ref KeyPrefixes, '']
 
@@ -77,9 +93,12 @@ Resources:
     Properties:
       MessageRetentionPeriod: 1209600 # 14 days
       VisibilityTimeout: 3600 # 1 hour
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt dlq.Arn
-        maxReceiveCount: 3
+      RedrivePolicy: !If
+        - EnableDlq
+        - deadLetterTargetArn: !GetAtt dlq.Arn
+          maxReceiveCount: 3
+        - !Ref AWS::NoValue
+
       Tags:
         - Key: elastio:resource
           Value: 'true'
@@ -90,6 +109,7 @@ Resources:
 
   dlq:
     Type: AWS::SQS::Queue
+    Condition: EnableDlq
     Properties:
       MessageRetentionPeriod: 1209600
       VisibilityTimeout: 30
@@ -103,7 +123,6 @@ Resources:
 
   eventRule:
     Type: AWS::Events::Rule
-    DependsOn: queue
     Properties:
       Description: !Sub Track S3 object change events in ${BucketName}
       EventPattern: !If
@@ -252,9 +271,16 @@ Resources:
       KeyPrefixes: !Ref KeyPrefixes
 
 Outputs:
+  eventRuleArn:
+    Value: !GetAtt eventRule.Arn
+  queueName:
+    Value: !GetAtt queue.QueueName
+  queueUrl:
+    Value: !GetAtt queue.QueueUrl
   queueArn:
     Value: !GetAtt queue.Arn
   dlqArn:
+    Condition: EnableDlq
     Value: !GetAtt dlq.Arn
   templateVersion:
     Value: "{{VERSION}}"

--- a/elastio-s3-changelog/upload.sh
+++ b/elastio-s3-changelog/upload.sh
@@ -45,7 +45,7 @@ sed -i ./*.yaml \
 
 aws s3 cp --recursive ./ "s3://${S3_BUCKET}/${s3_prefix}/${version}/"
 
-# Skip opening the link if we're in CI
+# Skip opening the link if we're on CI
 if [[ -v CI ]]; then
     exit 0
 fi

--- a/elastio-s3-changelog/upload.sh
+++ b/elastio-s3-changelog/upload.sh
@@ -45,6 +45,11 @@ sed -i ./*.yaml \
 
 aws s3 cp --recursive ./ "s3://${S3_BUCKET}/${s3_prefix}/${version}/"
 
+# Skip opening the link if we're in CI
+if [[ ! -v CI ]]; then
+    exit 0
+fi
+
 cfn_deep_link_parts=(
     "https://$AWS_REGION.console.aws.amazon.com/cloudformation/home"
     "?region=$AWS_REGION#/stacks/create/review?templateURL="

--- a/elastio-s3-changelog/upload.sh
+++ b/elastio-s3-changelog/upload.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Upload the templates into your S3 bucket for testing
+# Use this script like this:
+# ```bash
+# S3_BUCKET=bucket LINK_PARAMS='&param_BucketNames=foo,bar' ./elastio-s3-changelog/upload.sh
+# ```
+
+set -euxo pipefail
+
+s3_prefix=contrib/elastio-s3-changelog
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+temp_dir=$(mktemp -d)
+
+echo "Creating temp dir $temp_dir"
+
+function cleanup {
+    # Unset the trap to prevent an infinite loop
+    trap - SIGINT SIGTERM ERR EXIT
+
+    echo "Cleaning up $temp_dir"
+
+    rm -rf "$temp_dir"
+}
+
+cd elastio-s3-changelog
+
+version=$(cat version)
+
+AWS_REGION=${AWS_REGION:-us-east-2}
+
+cp ./*.yaml "$temp_dir"
+
+cd "$temp_dir"
+
+# Using `|` separator instead of `/` for prefix, because prefix
+# by itself contains a `/`
+sed -i ./*.yaml \
+    -e "s/{{AWS_REGION}}/$AWS_REGION/g" \
+    -e "s/{{S3_BUCKET}}/$S3_BUCKET/g" \
+    -e "s|{{S3_PREFIX}}|$s3_prefix|g" \
+    -e "s/{{VERSION}}/$version/g"
+
+aws s3 cp --recursive ./ "s3://${S3_BUCKET}/${s3_prefix}/${version}/"
+
+cfn_deep_link_parts=(
+    "https://$AWS_REGION.console.aws.amazon.com/cloudformation/home"
+    "?region=$AWS_REGION#/stacks/create/review?templateURL="
+    "https://$S3_BUCKET.s3.$AWS_REGION.amazonaws.com/"
+    "$s3_prefix/$version/cloudformation-multiple-buckets.yaml"
+    "&stackName=elastio-s3-changelog"
+    "${LINK_PARAMS:-}"
+)
+
+cfn_deep_link=$(IFS="" ; echo "${cfn_deep_link_parts[*]}")
+
+# Open the stack in the AWS Console
+xdg-open "$cfn_deep_link"

--- a/elastio-s3-changelog/upload.sh
+++ b/elastio-s3-changelog/upload.sh
@@ -46,7 +46,7 @@ sed -i ./*.yaml \
 aws s3 cp --recursive ./ "s3://${S3_BUCKET}/${s3_prefix}/${version}/"
 
 # Skip opening the link if we're in CI
-if [[ ! -v CI ]]; then
+if [[ -v CI ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
This parameter will probably be useful for AWS Backup Restore testing scenario where we don't need anything fancy, especially a DQL. This should reduce the CFN deployment time a bit.

Also moved the logic for uploading the CFN and replacing the placeholders to `upload.sh` so that it is usable for local development.