### PR TITLE
Add entropy scan support and remove requirement for `elastio:resource` tag on aws-backup-restored resource

### DIFF
--- a/aws-backup-elastio-integration/elastio-api/README.md
+++ b/aws-backup-elastio-integration/elastio-api/README.md
@@ -12,10 +12,13 @@ An encrypted and compressed copy of your data can be efficiently imported into a
 
 Elastio can scan the resource created as part of [AWS Backup restore testing](https://docs.aws.amazon.com/aws-backup/latest/devguide/restore-testing.html). The temporarily restored resource may be modified by Elastio directly for better performance and optimized cost. For example, Elastio stops the restored EC2 instance, detaches its volumes and attaches them to the worker EC2 instance that performs the scan.
 
-> ❗Elastio never modifies customer's data. IAM permissions restrict Elastio to modify **only** the resources listed below.
-> - Resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag.
-> - Resources created by AWS Backup restore testing. All such resources have `awsbackup-restore-test` tag.
-> During regular operation of Elastio all data is treated as sensitive and Elastio can only read and create snapshots of customer resources. AWS Backup restore testing is an exception where a temporarily restored resource is created and handed to the scanning software to restore-test it.
+---
+
+❗Elastio never modifies customer's data. IAM permissions restrict Elastio to modify **only** the resources listed below.
+- Resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag.
+- Resources created by AWS Backup restore testing. All such resources have `awsbackup-restore-test` tag.
+
+During regular operation of Elastio all data is treated as sensitive and Elastio can only read and create snapshots of customer resources. AWS Backup restore testing is an exception where a temporarily restored resource is created and handed to the scanning software to restore-test it.
 
 ## Lambda API
 

--- a/aws-backup-elastio-integration/elastio-api/README.md
+++ b/aws-backup-elastio-integration/elastio-api/README.md
@@ -15,7 +15,7 @@ Elastio can scan the resource created as part of [AWS Backup restore testing](ht
 ---
 
 ❗Elastio never modifies customer's production data. IAM permissions restrict Elastio to modify **only** the resources listed below.
-- Resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag.
+- Resources created and managed by Elastio itself. All such resources have `elastio:resource` tag.
 - Resources created by AWS Backup restore testing. All such resources have `awsbackup-restore-test` tag.
 
 During regular operation of Elastio all data is treated as sensitive and Elastio can only read and create snapshots of customer resources. AWS Backup restore testing is an exception where a temporarily restored resource is created and handed to the scanning software to restore-test it.

--- a/aws-backup-elastio-integration/elastio-api/README.md
+++ b/aws-backup-elastio-integration/elastio-api/README.md
@@ -12,10 +12,10 @@ An encrypted and compressed copy of your data can be efficiently imported into a
 
 Elastio can scan the resource created as part of [AWS Backup restore testing](https://docs.aws.amazon.com/aws-backup/latest/devguide/restore-testing.html). The temporarily restored resource may be modified by Elastio directly for better performance and optimized cost. For example, Elastio stops the restored EC2 instance, detaches its volumes and attaches them to the worker EC2 instance that performs the scan.
 
-> ❗Elastio never modifies customer's data. IAM permissions restrict Elastio to modify **only** resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag. During regular operation of Elastio all data is treated as sensitive and Elastio can only read and create snapshots of customer resources. AWS Backup restore testing is an exception where a temporarily restored resource is created and handed to the scanning software to restore-test it.
-
-For Elastio to be able to modify the temporarily restored resource, you must grant explicit permission by adding a tag `elastio:resource=true` to the restored resource.
-
+> ❗Elastio never modifies customer's data. IAM permissions restrict Elastio to modify **only** the resources listed below.
+> - Resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag.
+> - Resources created by AWS Backup restore testing. All such resources have `awsbackup-restore-test` tag.
+> During regular operation of Elastio all data is treated as sensitive and Elastio can only read and create snapshots of customer resources. AWS Backup restore testing is an exception where a temporarily restored resource is created and handed to the scanning software to restore-test it.
 
 ## Lambda API
 
@@ -69,6 +69,12 @@ Elastio Connector stack deploys an AWS Lambda function named `elastio-bg-jobs-se
 
     // Optional. If omitted then malware scan is disabled.
     "malware": true,
+
+    // Optional. If omitted then entropy scan is disabled. Warning! Enabling this
+    // kind of scan may result in a lot of noise alerts, since it checks for files
+    // becoming encrypted. File encryption often happens during regular operation
+    // of many applications, and thus doesn't immediately imply a ransomware attack.
+    "entropy": false,
 
     // Name of the AWS EventBridge event bus scan reports will be written to.
     //

--- a/aws-backup-elastio-integration/elastio-api/README.md
+++ b/aws-backup-elastio-integration/elastio-api/README.md
@@ -14,7 +14,7 @@ Elastio can scan the resource created as part of [AWS Backup restore testing](ht
 
 ---
 
-❗Elastio never modifies customer's data. IAM permissions restrict Elastio to modify **only** the resources listed below.
+❗Elastio never modifies customer's production data. IAM permissions restrict Elastio to modify **only** the resources listed below.
 - Resources created and managed by Elastio itself. All such resources have `elastio:resource=true` tag.
 - Resources created by AWS Backup restore testing. All such resources have `awsbackup-restore-test` tag.
 


### PR DESCRIPTION
Exposed entropy detection in AWS Backup integration API. 

@Silverhorn27 implemented IAM roles for Elastio Connector such that our BG job can directly tag the restored EC2 instance and volumes with `elastio:resource` if that EC2/EBS has `awsbackup-restore-test` tag on it (which we consider a temporary resource that we can mutate).

