### PR TITLE
Fix trying to get the SubnetId of a terminated instance

### DIFF
--- a/elastio-nat-provision-lambda/lambda.py
+++ b/elastio-nat-provision-lambda/lambda.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict, is_dataclass
 from datetime import datetime
 import json
 import os
@@ -15,16 +15,36 @@ NAT_CFN_PREFIX = os.environ['NAT_CFN_PREFIX']
 NAT_CFN_TEMPLATE_URL = os.environ['NAT_CFN_TEMPLATE_URL']
 STATE_MACHINE_ARN = os.environ['STATE_MACHINE_ARN']
 
+# It's not possible to serialize dataclasses with the default JSON encoder.
+# The reason Python restricts this is apparently to avoid confusion that
+# deserializing into dataclasses doesn't work (JSON serialization is lossy):
+# https://www.reddit.com/r/Python/comments/193lp4s/why_are_python_dataclasses_not_json_serializable/
+#
+# Some other primitive types in Python are also not JSON serializable, so we
+# handle their serilization manually.
+class AnyClassEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if is_dataclass(obj):
+            return asdict(obj)
+        elif isinstance(obj, datetime):
+            return obj.isoformat()
+        elif isinstance(obj, set):
+            return list(obj)
+        elif hasattr(obj, '__dict__'):
+            return obj.__dict__
+        else:
+            return super().default(obj)
+
 def to_json(value):
-    return json.dumps(value, indent=2)
+    return json.dumps(value, cls=AnyClassEncoder)
 
 def print_json(label: str, value):
     print(to_json({ label: value }))
 
 def lambda_handler(event, _context):
-    print(f"boto3 version: {boto3.__version__}")
-    print(f"botocore version: {botocore.__version__}")
-    print("event:", event)
+    print_json("boto3_version", boto3.__version__)
+    print_json("botocore_version", botocore.__version__)
+    print_json("event", event)
 
     if bool(event.get('elastio_scheduled_cleanup')):
         cleanup_nat(None, None)
@@ -58,7 +78,7 @@ def ensure_nat(instance_id):
         InstanceIds=[instance_id],
     )[0]
 
-    print("instance:", instance)
+    print_json("instance", instance)
 
     instance_vpc_id = instance['VpcId']
     instance_subnet_id = instance['SubnetId']
@@ -77,7 +97,7 @@ def ensure_nat(instance_id):
         'Subnets',
         Filters=[{'Name': 'vpc-id', 'Values': [instance_vpc_id]}],
     )}
-    print("subnets:", subnets)
+    print_json("subnets", subnets)
 
     route_tables = {rt['RouteTableId']: rt for rt in request(
         ec2,
@@ -85,7 +105,7 @@ def ensure_nat(instance_id):
         'RouteTables',
         Filters=[{'Name': 'vpc-id', 'Values': [instance_vpc_id]}],
     )}
-    print("route_tables:", subnets)
+    print_json("route_tables", route_tables)
 
     main_route_table_id = None
     subnet_to_route_table = {}
@@ -103,7 +123,7 @@ def ensure_nat(instance_id):
             subnet_to_route_table[subnet_id] = main_route_table_id
 
     public_subnets_ids = set(get_public_subnets(subnet_to_route_table, route_tables))
-    print("public_subnets_ids:", public_subnets_ids)
+    print_json("public_subnets_ids", public_subnets_ids)
 
     instance_route_table_id = subnet_to_route_table[instance_subnet_id]
     instance_route_table = route_tables[instance_route_table_id]
@@ -121,13 +141,29 @@ def ensure_nat(instance_id):
             print("Instance is running in a public subnet; exiting")
         return
 
+    nat_deployments = list(get_nat_deployments(subnets))
+    print_json("nat_deployments", nat_deployments)
+
     all_traffic_route = get_all_traffic_route(instance_route_table)
 
     if all_traffic_route is not None:
-        print(f"Route table already has a route for 0.0.0.0/0; exiting. {all_traffic_route}")
-        return
+        nat_gateway_id = all_traffic_route.get('NatGatewayId', None)
+        if nat_gateway_id is None:
+            print(
+                f"Route table already has a route for 0.0.0.0/0 "
+                f"which is not a NAT gateway. Exiting. Route: {to_json(all_traffic_route)}"
+            )
+            return
+
+        if not is_nat_managed_by_us(nat_deployments, nat_gateway_id):
+            print(
+                f"Route table already has a route for 0.0.0.0/0 "
+                f"which isn't managed by us. Exiting. Route: {to_json(all_traffic_route)}"
+            )
+            return
 
     nat_subnet_id = choose_subnet_for_nat(
+        nat_deployments,
         subnets,
         public_subnets_ids,
         instance_subnet_id,
@@ -138,7 +174,7 @@ def ensure_nat(instance_id):
         print("Unable to find a public subnet for NAT in the same availability zone; exiting")
         return
 
-    print(f"choosing {nat_subnet_id}")
+    print(f"Chose the following public subnet for NAT: {nat_subnet_id}")
 
     stack_name = f"{NAT_CFN_PREFIX}{nat_subnet_id}"
 
@@ -148,6 +184,22 @@ def ensure_nat(instance_id):
     else:
         print(f"Stack {stack_name} already exists or is in progress; nothing more to do.")
 
+def is_nat_managed_by_us(nat_deployments: list['NatDeployment'], suspect_nat_gateway_id: str) -> bool:
+    nat_deployment = next(
+        (
+            nat_deployment for nat_deployment in nat_deployments
+            if nat_deployment.nat_gateway_id == suspect_nat_gateway_id
+        ),
+        None
+    )
+
+    if nat_deployment is None:
+        print(f"NAT gateway {suspect_nat_gateway_id} is not managed by Elastio.")
+        return False
+
+    print(f"NAT gateway {suspect_nat_gateway_id} is managed by Elastio stack: {to_json(nat_deployment)}")
+
+    return True
 
 def get_stack_status(stack_name):
     try:
@@ -157,12 +209,15 @@ def get_stack_status(stack_name):
             'Stacks',
             StackName=stack_name,
         )
+
+        print_json("existing_nat_cfn_stack", stacks[0])
+
         return stacks[0]['StackStatus']
     except cfn.exceptions.ClientError as e:
         if 'does not exist' in str(e):
             print(f"Stack with a name {stack_name} does not exist.")
         else:
-            print(f"Error describing stack {stack_name}: {e}")
+            print(f"Error describing stack {stack_name}: {repr(e)}")
             print(f"Assuming the stack {stack_name} does not exist.")
         return None
 
@@ -208,20 +263,23 @@ def deploy_nat_stack(stack_name, subnet_id, route_table_id):
                 },
             ]
         )
-        print(f"Stack creation initiated for {stack_name}: {response}")
+        print(f"Stack creation initiated for {stack_name}: {to_json(response)}")
     except cfn.exceptions.AlreadyExistsException:
         print(f"Stack {stack_name} already exists")
 
 
-def choose_subnet_for_nat(subnets, public_subnets_ids, instance_subnet_id, vpc_id):
-    nat_deployments = list(get_nat_deployments(subnets))
-    print("nat_deployments:", nat_deployments)
-
+def choose_subnet_for_nat(
+    nat_deployments: list['NatDeployment'],
+    subnets,
+    public_subnets_ids,
+    instance_subnet_id,
+    vpc_id
+):
     instance_az = subnets[instance_subnet_id]['AvailabilityZone']
 
     for nat_deployment in nat_deployments:
         if nat_deployment.vpc_id == vpc_id and nat_deployment.az == instance_az:
-            print(f"Found already existing NAT deployment: {nat_deployment}")
+            print(f"Found already existing NAT deployment: {to_json(nat_deployment)}")
             return nat_deployment.subnet_id
 
     print(f"No existing deployments found for {vpc_id}/{instance_az}")
@@ -289,10 +347,10 @@ def cleanup_nat(current_instance_id, event_time):
         )
         print_json("pending_cleanups", pending_cleanups)
     except Exception as e:
-        print("Failed to list pending cleanups; assuming there are none", e)
+        print(f"Failed to list pending cleanups; assuming there are none: {repr(e)}")
         pending_cleanups = PendingCleanups()
 
-    active_statuses = ('pending', 'running', 'stopping')
+    active_statuses = ('pending', 'running', 'stopping', 'shutting-down')
 
     for nat_deployment in nat_deployments:
         nat_vpc_id = nat_deployment.vpc_id
@@ -312,7 +370,13 @@ def cleanup_nat(current_instance_id, event_time):
             if (
                 instance['State']['Name'] in active_statuses
                 and
-                instance.get('VpcId', None) == nat_vpc_id
+                (
+                    # In case when VPC ID of the instance is not known we just
+                    # assume it can potentially be the instance in the VPCs of the NAT
+                    instance.get('VpcId', None) == None
+                    or
+                    instance.get('VpcId', None) == nat_vpc_id
+                )
                 and
                 instance.get('Placement', {}).get('AvailabilityZone', None) == nat_az
             )
@@ -322,7 +386,7 @@ def cleanup_nat(current_instance_id, event_time):
 
         if active_instance is not None:
             print(
-                f"Found active elastio EC2 instance in {nat_vpc_id}/{nat_az};"
+                f"Found potentially active elastio EC2 instance in {nat_vpc_id}/{nat_az};"
                 f" skipping NAT gateway stack deletion."
                 f" Instance: {to_json(active_instance)}"
             )
@@ -432,12 +496,12 @@ def is_stack_needs_to_be_deleted(stack_name):
 def delete_nat_gateway_stack(stack_name):
     try:
         response = cfn.delete_stack(StackName=stack_name)
-        print(f"Stack deletion initiated for {stack_name}:", response)
+        print(f"Stack deletion initiated for {stack_name}: {to_json(response)}")
     except cfn.exceptions.ClientError as e:
         if 'does not exist' in str(e):
             print(f"Stack {stack_name} does not exist anymore")
         else:
-            print(f"Failed to delete stack {stack_name}", e)
+            print(f"Failed to delete stack {stack_name}: {repr(e)}")
 
 
 def get_nat_deployments(subnets):
@@ -457,6 +521,7 @@ def get_nat_deployments(subnets):
         ],
     )
     for nat in nat_gateways:
+        nat_gateway_id = nat['NatGatewayId']
         subnet_id = nat['SubnetId']
         subnet = subnets.get(subnet_id)
         if subnet is None:
@@ -467,10 +532,11 @@ def get_nat_deployments(subnets):
             tag['Value'] for tag in nat['Tags']
             if tag['Key'] == 'elastio:nat-provision-stack-id'
         )
-        yield NatDeployment(stack_id, vpc_id, subnet_id, az)
+        yield NatDeployment(nat_gateway_id, stack_id, vpc_id, subnet_id, az)
 
 @dataclass
 class NatDeployment:
+    nat_gateway_id: str
     stack_id: str
     vpc_id: str
     subnet_id: str


### PR DESCRIPTION
Terminated instances have no Vpc/Subnet info in their DescribeInstances response. The code was trying to figure out if there were any cleanups scheduled for the vpc+subnet pair to avoid running cleanup in them, however we can't get that info from DescribeInstances so the code was throwing `KeyError` exception.

The workaround is to uze the AZ info that is still available in the instance to consider all vpc+subnet pairs within the same AZ that can potentially contain the shutting down/terminated instance and thus delay cleanup in them.

Note that this may lead to a problem where there are several VPCs and there is a lot of activity in one VPC, but no activity in the other. In this case cleanup may be delayed indefinitely in the VPC without activity. A proper solution to this problem would involve storing the VPC/subnet state somewhere, for example instance tags, which would require more time to implement.

---

Another thing that was fixed: the code was giving up once it saw an existing `0.0.0.0/0` route in the private subnet. However, it's not correct, the code needs to check if that route points to a NAT gateway managed by this stack, and if it is - then still try to ensure it is alive. This could lead to code not creating a NAT gateway if the NAT stack was in the process of deletion

---

Another small fix is for a type error where `pending_cleanups` was assigned with an empty dict instead of an instance of `PendingCleanups` class during cold-path error handling, which lead to a "method not found" error.

# Testing

Tested this manually by running two jobs and observing different behaviors of termination timing combinations