### PR TITLE
Make upload scripts for s3-changelog and nat-gateway lambda consistent in using regional links to artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         needs.changes.outputs.ci == 'true'
       )
     env:
-      S3_BUCKET: elastio-prod-artifacts-us-east-2
+      S3_BUCKET_PREFIX: elastio-prod-artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/elastio-s3-changelog/cloudformation-multiple-buckets-with-macros.yaml
+++ b/elastio-s3-changelog/cloudformation-multiple-buckets-with-macros.yaml
@@ -46,7 +46,7 @@ Resources:
             EnableQrts: !Ref EnableQrts
             QrtsBatchSize: !Ref QrtsBatchSize
             QrtsMaxDelay: !Ref QrtsMaxDelay
-          TemplateURL: https://{{S3_BUCKET}}.s3.{{AWS_REGION}}.amazonaws.com/{{S3_PREFIX}}/{{VERSION}}/cloudformation-single-bucket.yaml
+          TemplateURL: !Sub https://{{S3_BUCKET_PREFIX}}-${AWS::Region}.s3.${AWS::Region}.amazonaws.com/{{S3_KEY_PREFIX}}/{{VERSION}}/cloudformation-single-bucket.yaml
 Outputs:
   templateVersion:
     Value: "{{VERSION}}"

--- a/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
+++ b/elastio-s3-changelog/cloudformation-multiple-buckets.yaml
@@ -102,7 +102,7 @@ Resources:
         EnableQrts: !Ref EnableQrts
         QrtsBatchSize: !Ref QrtsBatchSize
         QrtsMaxDelay: !Ref QrtsMaxDelay
-      TemplateURL: https://{{S3_BUCKET}}.s3.{{AWS_REGION}}.amazonaws.com/{{S3_PREFIX}}/{{VERSION}}/cloudformation-multiple-buckets-with-macros.yaml
+      TemplateURL: !Sub https://{{S3_BUCKET_PREFIX}}-${AWS::Region}.s3.${AWS::Region}.amazonaws.com/{{S3_KEY_PREFIX}}/{{VERSION}}/cloudformation-multiple-buckets-with-macros.yaml
 
 Outputs:
   templateVersion:

--- a/elastio-s3-changelog/upload.sh
+++ b/elastio-s3-changelog/upload.sh
@@ -3,12 +3,12 @@
 # Upload the templates into your S3 bucket for testing
 # Use this script like this:
 # ```bash
-# S3_BUCKET=bucket LINK_PARAMS='&param_BucketNames=foo,bar' ./elastio-s3-changelog/upload.sh
+# S3_BUCKET_PREFIX=bucket LINK_PARAMS='&param_BucketNames=foo,bar' ./elastio-s3-changelog/upload.sh
 # ```
 
 set -euxo pipefail
 
-s3_prefix=contrib/elastio-s3-changelog
+s3_key_prefix=contrib/elastio-s3-changelog
 
 trap cleanup SIGINT SIGTERM ERR EXIT
 
@@ -38,12 +38,11 @@ cd "$temp_dir"
 # Using `|` separator instead of `/` for prefix, because prefix
 # by itself contains a `/`
 sed -i ./*.yaml \
-    -e "s/{{AWS_REGION}}/$AWS_REGION/g" \
-    -e "s/{{S3_BUCKET}}/$S3_BUCKET/g" \
-    -e "s|{{S3_PREFIX}}|$s3_prefix|g" \
+    -e "s/{{S3_BUCKET_PREFIX}}/$S3_BUCKET_PREFIX/g" \
+    -e "s|{{S3_KEY_PREFIX}}|$s3_key_prefix|g" \
     -e "s/{{VERSION}}/$version/g"
 
-aws s3 cp --recursive ./ "s3://${S3_BUCKET}/${s3_prefix}/${version}/"
+aws s3 cp --recursive ./ "s3://$S3_BUCKET_PREFIX-$AWS_REGION/${s3_key_prefix}/${version}/"
 
 # Skip opening the link if we're on CI
 if [[ -v CI ]]; then
@@ -53,8 +52,8 @@ fi
 cfn_deep_link_parts=(
     "https://$AWS_REGION.console.aws.amazon.com/cloudformation/home"
     "?region=$AWS_REGION#/stacks/create/review?templateURL="
-    "https://$S3_BUCKET.s3.$AWS_REGION.amazonaws.com/"
-    "$s3_prefix/$version/cloudformation-multiple-buckets.yaml"
+    "https://$S3_BUCKET_PREFIX-$AWS_REGION.s3.$AWS_REGION.amazonaws.com/"
+    "$s3_key_prefix/$version/cloudformation-multiple-buckets.yaml"
     "&stackName=elastio-s3-changelog"
     "${LINK_PARAMS:-}"
 )


### PR DESCRIPTION
Merge of this PR is blocked by https://github.com/elastio/elastio/issues/9443 because we need to fix S3 artifacts replication first to make sure artifacts produced by master build after the merge of this PR are replicated.

Recently I fixed the CNF template in NAT gateway lambda stack to use the region of the CFN deployment when referencing the lambda ZIP artifact. For consistency I changed the references to CFN templates as well to use regional links to make sure we don't stumble on the same mistake next time we copy some parts of the CFN.

# Testing

Manually tested by deploying the changed CFN in my isolated dev account