### PR TITLE
Remove hard-coded tenant role ARN.

### DIFF
--- a/elastio-terraform-deployment/module/main.tf
+++ b/elastio-terraform-deployment/module/main.tf
@@ -38,7 +38,6 @@ locals {
     disableCustomerManagedIamPolicies = var.disable_customer_managed_iam_policies
     disableServiceLinkedRolesCreation = var.service_linked_roles == "tf"
     supportRoleExpirationDate         = var.support_role_expiration_date
-    tenantRoleArn                     = "arn:aws:iam::176355207749:role/vkryvenko.development.elastio.us"
   }
 
   enriched_connectors = [


### PR DESCRIPTION
This was used for development.  It's not needed in production, since the CFN generated by the Elastio tenant API will have the appropriate tenant role ARN hard-coded as the default value for the parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced management of service-linked roles for improved deployment processes.
	- Introduced new cloud connector deployment logic for better integration with existing services.
  
- **Bug Fixes**
	- Ensured proper dependencies between service-linked roles and CloudFormation stacks to prevent deployment issues. 

- **Refactor**
	- Reorganized local variables for clarity and efficiency in configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->